### PR TITLE
Show last C function for std::exceptions

### DIFF
--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -497,7 +497,7 @@ void* computerThread(void* data) {
         runComputer(comp, WS("bios.lua"));
 #endif
     } catch (std::exception &e) {
-        fprintf(stderr, "Uncaught exception while executing computer %d: %s\n", comp->id, e.what());
+        fprintf(stderr, "Uncaught exception while executing computer %d (last C function: %s): %s\n", comp->id, lastCFunction, e.what());
         queueTask([e](void*t)->void* {const std::string m = std::string("Uh oh, an uncaught exception has occurred! Please report this to https://www.craftos-pc.cc/bugreport. When writing the report, include the following exception message: \"Exception on computer thread: ") + e.what() + "\". The computer will now shut down.";  if (t != NULL) ((Terminal*)t)->showMessage(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str()); else if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str(), NULL); return NULL; }, comp->term);
         if (comp->L != NULL) {
             comp->event_lock.notify_all();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ static void* releaseNotesThread(void* data) {
         runComputer(comp, WS("debug/bios.lua"));
 #endif
     } catch (std::exception &e) {
-        fprintf(stderr, "Uncaught exception while executing computer %d: %s\n", comp->id, e.what());
+        fprintf(stderr, "Uncaught exception while executing computer %d (last C function: %s): %s\n", comp->id, lastCFunction, e.what());
         queueTask([e](void*t)->void* {const std::string m = std::string("Uh oh, an uncaught exception has occurred! Please report this to https://www.craftos-pc.cc/bugreport. When writing the report, include the following exception message: \"Exception on computer thread: ") + e.what() + "\". The computer will now shut down.";  if (t != NULL) ((Terminal*)t)->showMessage(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str()); else if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str(), NULL); return NULL; }, comp->term);
         if (comp->L != NULL) {
             comp->event_lock.notify_all();


### PR DESCRIPTION
Unfortunately I wasn't quick enough to make the 2.5 release for this particular fix (I ended up falling asleep early) but maybe we can still put it in 2.5.1 :P

This shows the last C function in the log when the program crashes.