### PR TITLE
Pixel and font size functions

### DIFF
--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -317,6 +317,10 @@ void runComputer(Computer * self, const path_t& bios_name) {
             lua_setglobal(L, "periphemu");
             lua_getglobal(L, "term");
             lua_pushnil(L);
+            lua_setfield(L, -2, "getPixelSize");
+            lua_pushnil(L);
+            lua_setfield(L, -2, "getFontSize");
+            lua_pushnil(L);
             lua_setfield(L, -2, "getGraphicsMode");
             lua_pushnil(L);
             lua_setfield(L, -2, "setGraphicsMode");

--- a/src/apis/term.cpp
+++ b/src/apis/term.cpp
@@ -140,6 +140,34 @@ static int term_getSize(lua_State *L) {
     return 2;
 }
 
+static int term_getPixelSize(lua_State* L) {
+    lastCFunction = __func__;
+
+    if (selectedRenderer == 1) {
+        lua_pushinteger(L, 51 * Terminal::fontWidth);
+        lua_pushinteger(L, 19 * Terminal::fontHeight);
+        return 2;
+    }
+
+    Terminal* term = get_comp(L)->term;
+    if (term == NULL) return 0;
+
+    lua_pushinteger(L, term->width * Terminal::fontWidth);
+    lua_pushinteger(L, term->height * Terminal::fontHeight);
+    return 2;
+}
+
+static int term_getFontSize(lua_State* L) {
+    lastCFunction = __func__;
+
+    Terminal* term = get_comp(L)->term;
+    if (term == NULL) return 0;
+
+    lua_pushinteger(L, Terminal::fontWidth);
+    lua_pushinteger(L, Terminal::fontHeight);
+    return 2;
+}
+
 static int term_clear(lua_State *L) {
     lastCFunction = __func__;
     if (selectedRenderer == 1) {
@@ -647,6 +675,8 @@ static luaL_reg term_reg[] = {
     {"getCursorPos", term_getCursorPos},
     {"getCursorBlink", term_getCursorBlink},
     {"getSize", term_getSize},
+    {"getPixelSize", term_getPixelSize},
+    {"getFontSize", term_getFontSize},
     {"clear", term_clear},
     {"clearLine", term_clearLine},
     {"setTextColour", term_setTextColor},

--- a/src/peripheral/monitor.cpp
+++ b/src/peripheral/monitor.cpp
@@ -118,6 +118,20 @@ int monitor::getSize(lua_State *L) {
     return 2;
 }
 
+int monitor::getPixelSize(lua_State *L) {
+    lastCFunction = __func__;
+    lua_pushinteger(L, term->width * Terminal::fontWidth);
+    lua_pushinteger(L, term->height * Terminal::fontHeight);
+    return 2;
+}
+
+int monitor::getFontSize(lua_State *L) {
+    lastCFunction = __func__;
+    lua_pushinteger(L, Terminal::fontWidth);
+    lua_pushinteger(L, Terminal::fontHeight);
+    return 2;
+}
+
 int monitor::clear(lua_State *L) {
     lastCFunction = __func__;
     if (selectedRenderer == 4) printf("TE:%d;\n", term->id);
@@ -556,6 +570,8 @@ int monitor::call(lua_State *L, const char * method) {
     else if (m == "setCursorBlink") return setCursorBlink(L);
     else if (m == "getCursorPos") return getCursorPos(L);
     else if (m == "getSize") return getSize(L);
+    else if (m == "getPixelSize") return getPixelSize(L);
+    else if (m == "getFontSize") return getFontSize(L);
     else if (m == "clear") return clear(L);
     else if (m == "clearLine") return clearLine(L);
     else if (m == "setTextColour") return setTextColor(L);

--- a/src/peripheral/monitor.hpp
+++ b/src/peripheral/monitor.hpp
@@ -28,6 +28,8 @@ private:
     int getCursorPos(lua_State *L);
     int getCursorBlink(lua_State *L);
     int getSize(lua_State *L);
+    int getPixelSize(lua_State *L);
+    int getFontSize(lua_State *L);
     int clear(lua_State *L);
     int clearLine(lua_State *L);
     int setTextColor(lua_State *L);


### PR DESCRIPTION
For convenience and for redirects to override. This allows:

- Terminal width/height that does not align with character boundaries
- Nonstandard font sizes

Of course, only if willingly implemented in software.

This is probably pushing it a little, but providing functions like these in the "standard library" will encourage more programs to use them from the start.