### PR TITLE
Switch to C++17 `std::filesystem` API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
 
         }
 
-        Invoke-Environment "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        Invoke-Environment "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         $tag = git rev-parse --short HEAD
         Set-Item ENV:ExternalCompilerOptions /DCRAFTOSPC_COMMIT='\"'$tag'\"'
         msbuild "CraftOS-PC 2.sln" /p:Configuration=ReleaseC

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
     - name: Restore vcpkg cache
       uses: lukka/run-vcpkg@v10
       with:
-        vcpkgGitCommitId: 8b62d95a81afcb9efe74bebeb62f04c1e0e2a003
+        vcpkgGitCommitId: 68b7fec22eb5fd9c0236b1e42b3c0deb8e771b37
     - name: Prepare environment
       run: |
         git submodule update --init --recursive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Download ROM & CC:T
       run: |
         sudo git clone https://github.com/MCJack123/craftos2-rom /usr/local/share/craftos
-        git clone --branch v1.16.5-1.100.0 https://github.com/SquidDev-CC/CC-Tweaked ../CC-Tweaked
+        git clone --branch v1.16.5-1.100.9 https://github.com/SquidDev-CC/CC-Tweaked ../CC-Tweaked
         patch -p1 -d ../CC-Tweaked < resources/CCT-Tests.patch
     - name: Install dependencies
       run: |

--- a/CraftOS-PC 2.vcxproj
+++ b/CraftOS-PC 2.vcxproj
@@ -469,7 +469,7 @@
       <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
-      <DisableSpecificWarnings>C26812;C4005</DisableSpecificWarnings>
+      <DisableSpecificWarnings>26812;4005</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>

--- a/CraftOS-PC 2.vcxproj
+++ b/CraftOS-PC 2.vcxproj
@@ -62,67 +62,67 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStandalone|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseC|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStandalone|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStandalone|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseC|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseC|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -272,6 +272,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\curl.7.65.3\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -290,6 +292,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\curl.7.65.3\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -309,6 +313,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\curl.7.65.3\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -328,6 +334,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)packages\curl.7.65.3\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -351,7 +359,7 @@
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;HAVE_STRERROR_S;__STDC_LIB_EXT1__;_DEBUG</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)api;$(SolutionDir)craftos2-lua\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatSpecificWarningsAsErrors>4013</TreatSpecificWarningsAsErrors>
       <WarningLevel>Level1</WarningLevel>
       <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
@@ -379,7 +387,7 @@
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;HAVE_STRERROR_S;_DEBUG;CRASHREPORT_API_KEY</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)api;$(SolutionDir)craftos2-lua\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatSpecificWarningsAsErrors>4013</TreatSpecificWarningsAsErrors>
       <WarningLevel>Level1</WarningLevel>
       <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
@@ -411,6 +419,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <DisableSpecificWarnings>26812;4005</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -435,6 +444,7 @@
       <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -460,6 +470,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <DisableSpecificWarnings>C26812;C4005</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -484,6 +495,7 @@
       <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -507,8 +519,9 @@
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <AdditionalOptions>$(ExternalCompilerOptions) /d2SSAOptimizer- %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <DisableSpecificWarnings>26812;4005</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -533,6 +546,7 @@
       <AdditionalOptions>$(ExternalCompilerOptions) /d2SSAOptimizer- %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ CraftOS-PC v2.2 moves the save directory to be more appropriate for each platfor
 ## Building
 ### Requirements
 * [CraftOS ROM package](https://github.com/MCJack123/craftos2-rom)
-* Compiler supporting C++14
-  * Linux: G++ 4.9+, make
-  * Mac: Xcode CLI tools (xcode-select --install)
+* Compiler supporting C++17
+  * Linux: G++ 8.0+, make
+  * Mac: Xcode 10.2+ CLI tools (xcode-select --install)
   * Windows: Visual Studio 2019
 * SDL 2.0.8+ (may work on older versions on non-Linux)
-* OpenSSL 1.1.1 (for POCO)
+* OpenSSL 1.1.1/3.x (for POCO)
 * POCO 1.5.0+: NetSSL & JSON libraries + dependencies
   * Foundation
   * Util
@@ -86,7 +86,6 @@ CraftOS-PC v2.2 moves the save directory to be more appropriate for each platfor
   * Net
   * NetSSL
     * On Windows, you'll need to modify the `poco` port to use OpenSSL. Simply open `vcpkg\ports\poco\portfile.cmake`, find `ENABLE_NETSSL_WIN`, and replace it with `FORCE_OPENSSL`. Then install as normal.
-* Windows: dirent.h (install with NuGet OR vcpkg)
 * Windows: [vcpkg](https://github.com/microsoft/vcpkg)
 
 #### Optional

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CraftOS-PC v2.2 moves the save directory to be more appropriate for each platfor
 * Compiler supporting C++17
   * Linux: G++ 8.0+, make
   * Mac: Xcode 10.2+ CLI tools (xcode-select --install)
-  * Windows: Visual Studio 2019
+  * Windows: Visual Studio 2022
 * SDL 2.0.8+ (may work on older versions on non-Linux)
 * OpenSSL 1.1.1/3.x (for POCO)
 * POCO 1.5.0+: NetSSL & JSON libraries + dependencies

--- a/api/Computer.hpp
+++ b/api/Computer.hpp
@@ -50,16 +50,16 @@ struct Computer {
     // The following fields are available in API version 10.0. No structure version check is required to use these.
 
     // These properties are the most likely to be useful for reading data about a computer.
-    int id;                                                                 // The computer's ID
-    int running = 0;                                                        // The current run state for the computer (0 = off, 1 = on, 2 = restarting)
-    lua_State *L = NULL;                                                    // The global Lua state for the computer
-    Terminal * term;                                                        // A pointer to the terminal object for the computer (warning: may be NULL in headless mode!)
-    struct computer_configuration * config;                                 // The configuration structure for this computer
-    path_t dataDir;                                                         // The path to the computer's data directory
-    std::vector< std::tuple<std::list<std::string>, path_t, bool> > mounts; // A list of all current mounts on the computer. Each entry is stored as a tuple with 1) a list of internal path components, 2) the real path that's mounted, and 3) whether the mount is read-only
-    std::unordered_map<std::string, peripheral*> peripherals;               // A dictionary holding information about what peripherals are attached on each side
-    std::mutex peripherals_mutex;                                           // A mutex locking access to the peripheral dictionary (lock this before modifying the peripheral list!)
-    unsigned char colors = 0xF0;                                            // The current foreground/background color pair for drawing text to the terminal
+    int id;                                                                  // The computer's ID
+    int running = 0;                                                         // The current run state for the computer (0 = off, 1 = on, 2 = restarting)
+    lua_State *L = NULL;                                                     // The global Lua state for the computer
+    Terminal * term;                                                         // A pointer to the terminal object for the computer (warning: may be NULL in headless mode!)
+    struct computer_configuration * config;                                  // The configuration structure for this computer
+    _path_t dataDir;                                                         // The path to the computer's data directory
+    std::vector< std::tuple<std::list<std::string>, _path_t, bool> > mounts; // A list of all current mounts on the computer. Each entry is stored as a tuple with 1) a list of internal path components, 2) the real path that's mounted, and 3) whether the mount is read-only
+    std::unordered_map<std::string, peripheral*> peripherals;                // A dictionary holding information about what peripherals are attached on each side
+    std::mutex peripherals_mutex;                                            // A mutex locking access to the peripheral dictionary (lock this before modifying the peripheral list!)
+    unsigned char colors = 0xF0;                                             // The current foreground/background color pair for drawing text to the terminal
     
     // These properties are provided explicitly for the use of plugin developers.
     std::unordered_map<int, void *> userdata;                                                  // A free dictionary for use by plugins to store any data that is linked to a single computer

--- a/api/CraftOS-PC.hpp
+++ b/api/CraftOS-PC.hpp
@@ -13,6 +13,7 @@
 
 #include "Computer.hpp"
 #include "FileEntry.hpp"
+#define path_t _path_t
 
 #if (defined(_WIN32) && (!defined(_MSC_VER) || _MSC_VER < 1900)) || (defined(__APPLE__) && !defined(__clang__))
 #warning An incompatible C++ library may be in use. This plugin may fail to work properly.

--- a/api/CraftOS-PC.hpp
+++ b/api/CraftOS-PC.hpp
@@ -14,6 +14,7 @@
 #include "Computer.hpp"
 #include "FileEntry.hpp"
 #define path_t _path_t
+#define to_path_t _to_path_t
 
 #if (defined(_WIN32) && (!defined(_MSC_VER) || _MSC_VER < 1900)) || (defined(__APPLE__) && !defined(__clang__))
 #warning An incompatible C++ library may be in use. This plugin may fail to work properly.

--- a/api/FileEntry.hpp
+++ b/api/FileEntry.hpp
@@ -13,6 +13,7 @@
 #define CRAFTOS_PC_FILEENTRY_HPP
 #include <algorithm>
 #include <codecvt>
+#include <filesystem>
 #include <locale>
 #include <map>
 #include <regex>
@@ -60,29 +61,27 @@ struct FileEntry {
      * @throw std::runtime_error If one of the non-final nodes is a file
      * @throw std::out_of_range If one of the nodes doesn't exist
      */
-    FileEntry& path(std::string path) noexcept(false) {
-        std::replace(path.begin(), path.end(), '\\', '/');
-        std::stringstream ss(path);
-        std::string item;
+    FileEntry& path(std::filesystem::path path) noexcept(false) {
         FileEntry * retval = this;
-        while (std::getline(ss, item, '/')) if (!item.empty() && !std::regex_match(path, std::regex("\\d+:"))) retval = &(*retval)[item];
+        for (const auto& item : path) if (!std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>("\\d+:"))) retval = &(*retval)[item];
         return *retval;
+    }
+    FileEntry& path(std::string path) noexcept(false) {
+        return this->path(std::filesystem::path(path));
     }
     FileEntry& path(std::wstring path) noexcept(false) {
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        return this->path(converter.to_bytes(path));
+        return this->path(std::filesystem::path(path));
     }
-    const FileEntry& path(std::string path) const noexcept(false) {
-        std::replace(path.begin(), path.end(), '\\', '/');
-        std::stringstream ss(path);
-        std::string item;
+    const FileEntry& path(std::filesystem::path path) const noexcept(false) {
         const FileEntry * retval = this;
-        while (std::getline(ss, item, '/')) if (!item.empty() && !std::regex_match(item, std::regex("\\d+:"))) retval = &(*retval)[item];
+        for (const auto& item : path) if (!std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>("\\d+:"))) retval = &(*retval)[item];
         return *retval;
     }
+    const FileEntry& path(std::string path) const noexcept(false) {
+        return this->path(std::filesystem::path(path));
+    }
     const FileEntry& path(std::wstring path) const noexcept(false) {
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        return this->path(converter.to_bytes(path));
+        return this->path(std::filesystem::path(path));
     }
 };
 

--- a/api/FileEntry.hpp
+++ b/api/FileEntry.hpp
@@ -63,7 +63,7 @@ struct FileEntry {
      */
     FileEntry& path(std::filesystem::path path) noexcept(false) {
         FileEntry * retval = this;
-        for (const auto& item : path) if (!std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>("\\d+:"))) retval = &(*retval)[item];
+        for (const auto& item : path) if (item.string() != "." && !std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>(std::filesystem::path("\\d+:").native()))) retval = &(*retval)[item.string()];
         return *retval;
     }
     FileEntry& path(std::string path) noexcept(false) {
@@ -74,7 +74,7 @@ struct FileEntry {
     }
     const FileEntry& path(std::filesystem::path path) const noexcept(false) {
         const FileEntry * retval = this;
-        for (const auto& item : path) if (!std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>("\\d+:"))) retval = &(*retval)[item];
+        for (const auto& item : path) if (item.string() != "." && !std::regex_match(item.native(), std::basic_regex<std::filesystem::path::value_type>(std::filesystem::path("\\d+:").native()))) retval = &(*retval)[item.string()];
         return *retval;
     }
     const FileEntry& path(std::string path) const noexcept(false) {

--- a/api/lib.hpp
+++ b/api/lib.hpp
@@ -33,12 +33,13 @@ struct Computer;
 /// To abstract this difference in implementation, a path_t type is used to allow the correct
 /// string type to be used on each platform. Since the type only changes when the platform changes,
 /// this should not have a negative impact on ABI stability.
+/// @deprecated This is retained for ABI compatibility - the next API will use std::filesystem::path instead.
 #ifdef _WIN32
-typedef std::wstring path_t;
-#define to_path_t std::to_wstring
+typedef std::wstring _path_t;
+#define _to_path_t std::to_wstring
 #else
-typedef std::string path_t;
-#define to_path_t std::to_string
+typedef std::string _path_t;
+#define _to_path_t std::to_string
 #endif
 
 // The library_t structure is used to hold information about an API.

--- a/configure
+++ b/configure
@@ -2706,7 +2706,7 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-CXXFLAGS="$CXXFLAGS -std=c++14"
+CXXFLAGS="$CXXFLAGS -std=c++17"
 CPPFLAGS="$CPPFLAGS -Icraftos2-lua/include -I/usr/local/opt/openssl/include"
 LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
 
@@ -4080,15 +4080,15 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++14" >&5
-printf %s "checking whether C++ compiler accepts -std=c++14... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++17" >&5
+printf %s "checking whether C++ compiler accepts -std=c++17... " >&6; }
 if test ${ax_cv_check_cxxflags___std_cpp14+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
 
   ax_check_save_flags=$CXXFLAGS
-  CXXFLAGS="$CXXFLAGS  -std=c++14"
+  CXXFLAGS="$CXXFLAGS  -std=c++17"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -4115,7 +4115,7 @@ if test "x$ax_cv_check_cxxflags___std_cpp14" = xyes
 then :
   :
 else $as_nop
-  as_fn_error $? "C++ compiler does not support -std=c++14." "$LINENO" 5
+  as_fn_error $? "C++ compiler does not support -std=c++17." "$LINENO" 5
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,18 +44,18 @@ if test "x$enable_wasm" = "xyes"; then
     CC=emcc
     CXX=em++
     CPPFLAGS="$CPPFLAGS -I$with_wasm_poco/include -Icraftos2-lua/include -Iapi -DNO_CLI -DNO_PNG -DNO_WEBP -DPRINT_TYPE=1"
-    CXXFLAGS="$CXXFLAGS -std=c++11 -s USE_SDL=2 -s USE_PTHREADS=1 -s USE_SDL_MIXER=2 -Wno-implicit-const-int-float-conversion -Wno-pthreads-mem-growth"
+    CXXFLAGS="$CXXFLAGS -std=c++17 -s USE_SDL=2 -s USE_PTHREADS=1 -s USE_SDL_MIXER=2 -Wno-implicit-const-int-float-conversion -Wno-pthreads-mem-growth"
     LDFLAGS="$LDFLAGS -L$with_wasm_poco/lib -lidbfs.js -s USE_SDL=2 -s USE_SDL_MIXER=2 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s TOTAL_MEMORY=33554432 -s DISABLE_EXCEPTION_CATCHING=0 -s FETCH=1 -s DEMANGLE_SUPPORT=1 -s EXTRA_EXPORTED_RUNTIME_METHODS=$SQBROP\"ccall\",\"cwrap\"$SQBRCL -s ASYNCIFY -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy -Wno-pthreads-mem-growth"
 fi
 
 # Check language
 AC_LANG([C++])
-CXXFLAGS="$CXXFLAGS -std=c++14"
+CXXFLAGS="$CXXFLAGS -std=c++17"
 CPPFLAGS="$CPPFLAGS -Icraftos2-lua/include -I/usr/local/opt/openssl/include"
 LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
 AC_PROG_CC
 AC_PROG_CXX
-AX_CHECK_COMPILE_FLAG([-std=c++14], [], [AC_MSG_ERROR([C++ compiler does not support -std=c++14.])])
+AX_CHECK_COMPILE_FLAG([-std=c++17], [], [AC_MSG_ERROR([C++ compiler does not support -std=c++17.])])
 
 # Find required libraries
 

--- a/examples/ccemux.vcxproj
+++ b/examples/ccemux.vcxproj
@@ -40,41 +40,41 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -137,6 +137,8 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)craftos2-lua\include;$(SolutionDir)api</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/resources/CraftOS-PC.exe.manifest
+++ b/resources/CraftOS-PC.exe.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity
       type="win32"
       name="CraftOS-PC"
-      version="2.6.6.0"
+      version="2.7.0.0"
       processorArchitecture="*"
     />
   <description>Advanced ComputerCraft Emulator</description>

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -21,13 +21,13 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.6</string>
+	<string>2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSApplicationCategoryType</key>
 	<string>Unknown</string>
 	<key>CFBundleVersion</key>
-	<string>2.6.6</string>
+	<string>2.7.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (C) 2019-2022 JackMacWindows.</string>
 	<key>NSHighResolutionCapable</key>

--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -788,6 +788,7 @@ void* computerThread(void* data) {
                     comp->rawFileStack = NULL;
                 }
             }
+            if (selectedRenderer == 1) returnValue = 1;
         } catch (std::exception &e) {
             fprintf(stderr, "Uncaught exception while executing computer %d (last C function: %s): %s\n", comp->id, lastCFunction, e.what());
             queueTask([e](void*t)->void* {const std::string m = std::string("Uh oh, an uncaught exception has occurred! Please report this to https://www.craftos-pc.cc/bugreport. When writing the report, include the following exception message: \"Exception on computer thread: ") + e.what() + "\". The computer will now shut down.";  if (t != NULL) ((Terminal*)t)->showMessage(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str()); else if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str(), NULL); return NULL; }, comp->term);
@@ -806,6 +807,7 @@ void* computerThread(void* data) {
                     comp->rawFileStack = NULL;
                 }
             }
+            if (selectedRenderer == 1) returnValue = 1;
         }
         first = false;
     } while ((config.keepOpenOnShutdown || config.standardsMode) && !comp->requestedExit);

--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -765,7 +765,7 @@ void* computerThread(void* data) {
         }
         try {
 #ifdef STANDALONE_ROM
-            runComputer(comp, "standalone BIOS", standaloneBIOS));
+            runComputer(comp, "standalone BIOS", standaloneBIOS);
 #else
             runComputer(comp, "bios.lua");
 #endif

--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -587,7 +587,7 @@ void runComputer(Computer * self, const path_t& bios_name, const std::string& bi
 
         /* Load the file containing the script we are going to run */
 #ifdef STANDALONE_ROM
-        status = luaL_loadstring(self->coro, bios_data.c_str());
+        status = luaL_loadbuffer(self->coro, bios_data.c_str(), bios_data.size(), "@bios.lua");
         path_t bios_path_expanded("standalone ROM");
 #else
         path_t bios_path_expanded = getROMPath() / bios_name;

--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -11,7 +11,7 @@
 extern "C" {
 #include <lualib.h>
 }
-#include <dirent.h>
+#include <fstream>
 #include <thread>
 #include <unordered_set>
 #include <configuration.hpp>
@@ -97,36 +97,29 @@ Computer::Computer(int i, bool debug): isDebugger(debug) {
     addVirtualMount(this, standaloneROM, "rom");
     if (debug) addVirtualMount(this, standaloneDebug, "debug");
 #else
-#ifdef _WIN32
-    if (!addMount(this, getROMPath() + WS("\\rom"), "rom", ::config.romReadOnly)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount ROM"); }
-    if (debug) if (!addMount(this, getROMPath() + WS("\\debug"), "debug", true)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount debugger ROM"); }
-#else
-    if (!addMount(this, getROMPath() + WS("/rom"), "rom", ::config.romReadOnly)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount ROM"); }
-    if (debug) if (!addMount(this, getROMPath() + WS("/debug"), "debug", true)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount debugger ROM"); }
-#endif // _WIN32
+    if (!addMount(this, getROMPath() / "rom", "rom", ::config.romReadOnly)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount ROM"); }
+    if (debug) if (!addMount(this, getROMPath() / "debug", "debug", true)) { if (::config.standardsMode && term) { displayFailure(term, "Cannot mount ROM"); orphanedTerminals.insert(term); } else if (term) term->factory->deleteTerminal(term); throw std::runtime_error("Could not mount debugger ROM"); }
 #endif // STANDALONE_ROM
     // Mount custom directories from the command line
     for (auto m : customMounts) {
         bool ok = false;
         switch (std::get<2>(m)) {
-            case -1: if (::config.mount_mode != MOUNT_MODE_NONE) ok = addMount(this, wstr(std::get<1>(m)), std::get<0>(m).c_str(), ::config.mount_mode != MOUNT_MODE_RW); break; // use default mode
-            case 0: ok = addMount(this, wstr(std::get<1>(m)), std::get<0>(m).c_str(), true); break; // force RO
-            default: ok = addMount(this, wstr(std::get<1>(m)), std::get<0>(m).c_str(), false); break; // force RW
+            case -1: if (::config.mount_mode != MOUNT_MODE_NONE) ok = addMount(this, std::get<1>(m), std::get<0>(m).c_str(), ::config.mount_mode != MOUNT_MODE_RW); break; // use default mode
+            case 0: ok = addMount(this, std::get<1>(m), std::get<0>(m).c_str(), true); break; // force RO
+            default: ok = addMount(this, std::get<1>(m), std::get<0>(m).c_str(), false); break; // force RW
         }
         if (!ok) fprintf(stderr, "Could not mount custom mount path at %s\n", std::get<1>(m).c_str());
     }
     mounter_initializing = false;
     // Get the computer's data directory
     if (customDataDirs.find(id) != customDataDirs.end()) dataDir = customDataDirs[id];
-#ifdef _WIN32
-    else dataDir = computerDir + WS("\\") + to_path_t(id);
-#else
-    else dataDir = computerDir + WS("/") + to_path_t(id);
-#endif
+    else dataDir = computerDir / std::to_string(id);
     // Create the root directory
-    if (createDirectory(dataDir) != 0) {
+    std::error_code e;
+    fs::create_directories(dataDir, e);
+    if (e) {
         if (term) term->factory->deleteTerminal(term);
-        throw std::runtime_error("Could not create computer data directory");
+        throw std::runtime_error("Could not create computer data directory: " + e.message());
     }
     config = new computer_configuration(_config);
 }
@@ -173,7 +166,7 @@ extern "C" {
     /* export */ int db_breakpoint(lua_State *L) {
         Computer * computer = get_comp(L);
         const int id = !computer->breakpoints.empty() ? computer->breakpoints.rbegin()->first + 1 : 1;
-        computer->breakpoints[id] = std::make_pair("@/" + astr(fixpath(computer, luaL_checkstring(L, 1), false, false)), luaL_checkinteger(L, 2));
+        computer->breakpoints[id] = std::make_pair("@/" + fixpath(computer, luaL_checkstring(L, 1), false, false).string(), luaL_checkinteger(L, 2));
         if (!computer->hasBreakpoints) computer->forceCheckTimeout = true;
         computer->hasBreakpoints = true;
         lua_sethook(computer->L, termHook, LUA_MASKCOUNT | LUA_MASKLINE | LUA_MASKRET | LUA_MASKCALL | LUA_MASKERROR | LUA_MASKRESUME | LUA_MASKYIELD, 1000000);
@@ -207,8 +200,9 @@ extern "C" {
 
 static const char * file_reader(lua_State *L, void * ud, size_t *size) {
     static char file_read_tmp[4096];
-    if (feof((FILE*)ud)) return NULL;
-    *size = fread(file_read_tmp, 1, 4096, (FILE*)ud);
+    std::ifstream * file = (std::ifstream*)ud;
+    if (file->eof()) return NULL;
+    *size = file->readsome(file_read_tmp, 4096);
     return file_read_tmp;
 }
 
@@ -343,7 +337,7 @@ static const luaL_Reg lualibs[] = {
 static int doNothing(lua_State *L) {return 0;}
 
 // Main computer loop
-void runComputer(Computer * self, const path_t& bios_name) {
+void runComputer(Computer * self, const path_t& bios_name, const std::string& bios_data) {
     self->running = 1;
     if (self->L != NULL) lua_close(self->L);
     setjmp(self->on_panic);
@@ -454,8 +448,7 @@ void runComputer(Computer * self, const path_t& bios_name) {
                     lua_setglobal(L, "_CCPC_PLUGIN_ERRORS");
                 }
                 for (const auto& err : globalPluginErrors) {
-                    path_t bname = err.first.substr(err.first.find_last_of(PATH_SEPC) + 1);
-                    lua_pushstring(L, astr(bname.substr(0, bname.find_first_of('.'))).c_str());
+                    lua_pushstring(L, err.first.stem().string().c_str());
                     lua_pushstring(L, err.second.c_str());
                     lua_settable(L, -3);
                 }
@@ -570,11 +563,11 @@ void runComputer(Computer * self, const path_t& bios_name) {
                     fclose(in);
                 } else script = "printError('Could not load startup script: " + std::string(strerror(errno)) + "')";
             }
-            lua_pushlstring(L, script.c_str(), script.size());
+            pushstring(L, script);
             lua_setglobal(L, "_CCPC_STARTUP_SCRIPT");
         }
         if (!script_args.empty()) {
-            lua_pushlstring(L, script_args.c_str(), script_args.length());
+            pushstring(L, script_args);
             lua_setglobal(L, "_CCPC_STARTUP_ARGS");
         }
         lua_pushcfunction(L, term_benchmark);
@@ -593,18 +586,14 @@ void runComputer(Computer * self, const path_t& bios_name) {
 
         /* Load the file containing the script we are going to run */
 #ifdef STANDALONE_ROM
-        status = luaL_loadstring(self->coro, astr(bios_name).c_str());
-        path_t bios_path_expanded = WS("standalone ROM");
+        status = luaL_loadstring(self->coro, bios_data.c_str());
+        path_t bios_path_expanded = "standalone ROM";
 #else
-#ifdef WIN32
-        path_t bios_path_expanded = getROMPath() + WS("\\") + bios_name;
-#else
-        path_t bios_path_expanded = getROMPath() + WS("/") + bios_name;
-#endif
-        FILE * bios_file = platform_fopen(bios_path_expanded.c_str(), "r");
-        if (bios_file != NULL) {
-            status = lua_load(self->coro, file_reader, bios_file, "@bios.lua");
-            fclose(bios_file);
+        path_t bios_path_expanded = getROMPath() / bios_name;
+        std::ifstream bios_file(bios_path_expanded);
+        if (bios_file.is_open()) {
+            status = lua_load(self->coro, file_reader, &bios_file, "@bios.lua");
+            bios_file.close();
         } else {
             status = LUA_ERRFILE;
             lua_pushstring(L, strerror(errno));
@@ -613,13 +602,13 @@ void runComputer(Computer * self, const path_t& bios_name) {
         if (status || !lua_isfunction(self->coro, -1)) {
             /* If something went wrong, error message is at the top of */
             /* the stack */
-            fprintf(stderr, "Couldn't load BIOS: %s (%s). Please make sure the CraftOS ROM is installed properly. (See https://www.craftos-pc.cc/docs/error-messages for more information.)\n", astr(bios_path_expanded).c_str(), lua_tostring(L, -1));
+            fprintf(stderr, "Couldn't load BIOS: %s (%s). Please make sure the CraftOS ROM is installed properly. (See https://www.craftos-pc.cc/docs/error-messages for more information.)\n", bios_path_expanded.string().c_str(), lua_tostring(L, -1));
             if (::config.standardsMode) displayFailure(self->term, "Error loading bios.lua");
             else queueTask([bios_path_expanded](void* term)->void*{
                 ((Terminal*)term)->showMessage(
                     SDL_MESSAGEBOX_ERROR, "Couldn't load BIOS", 
                     std::string(
-                        "Couldn't load BIOS from " + astr(bios_path_expanded) + ". Please make sure the CraftOS ROM is installed properly. (See https://www.craftos-pc.cc/docs/error-messages for more information.)"
+                        "Couldn't load BIOS from " + bios_path_expanded.string() + ". Please make sure the CraftOS ROM is installed properly. (See https://www.craftos-pc.cc/docs/error-messages for more information.)"
                     ).c_str()
                 ); 
                 return NULL;
@@ -775,11 +764,11 @@ void* computerThread(void* data) {
 #endif
         }
         try {
-    #ifdef STANDALONE_ROM
-            runComputer(comp, wstr(standaloneBIOS));
-    #else
-            runComputer(comp, WS("bios.lua"));
-    #endif
+#ifdef STANDALONE_ROM
+            runComputer(comp, "standalone BIOS", standaloneBIOS));
+#else
+            runComputer(comp, "bios.lua");
+#endif
         } catch (Poco::Exception &e) {
             fprintf(stderr, "Uncaught exception while executing computer %d (last C function: %s): %s\n", comp->id, lastCFunction, e.displayText().c_str());
             queueTask([e](void*t)->void* {const std::string m = "Uh oh, an uncaught exception has occurred! Please report this to https://www.craftos-pc.cc/bugreport. When writing the report, include the following exception message: \"Poco exception on computer thread: " + e.displayText() + "\". The computer will now shut down.";  if (t != NULL) ((Terminal*)t)->showMessage(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str()); else if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Uncaught Exception", m.c_str(), NULL); return NULL; }, comp->term);

--- a/src/Computer.cpp
+++ b/src/Computer.cpp
@@ -202,7 +202,8 @@ static const char * file_reader(lua_State *L, void * ud, size_t *size) {
     static char file_read_tmp[4096];
     std::ifstream * file = (std::ifstream*)ud;
     if (file->eof()) return NULL;
-    *size = file->readsome(file_read_tmp, 4096);
+    file->read(file_read_tmp, 4096);
+    *size = file->gcount();
     return file_read_tmp;
 }
 
@@ -587,7 +588,7 @@ void runComputer(Computer * self, const path_t& bios_name, const std::string& bi
         /* Load the file containing the script we are going to run */
 #ifdef STANDALONE_ROM
         status = luaL_loadstring(self->coro, bios_data.c_str());
-        path_t bios_path_expanded = "standalone ROM";
+        path_t bios_path_expanded("standalone ROM");
 #else
         path_t bios_path_expanded = getROMPath() / bios_name;
         std::ifstream bios_file(bios_path_expanded);

--- a/src/apis/config.cpp
+++ b/src/apis/config.cpp
@@ -105,7 +105,7 @@ static int config_get(lua_State *L) {
             switch (std::get<0>(userConfig[name])) {
                 case 0: lua_pushboolean(L, config.pluginData[name] == "true"); break;
                 case 1: lua_pushinteger(L, std::stoi(config.pluginData[name])); break;
-                case 2: lua_pushlstring(L, config.pluginData[name].c_str(), config.pluginData[name].size()); break;
+                case 2: pushstring(L, config.pluginData[name]); break;
                 case 3: return luaL_error(L, "Invalid type"); // maybe fix this later?
                 default: lua_pushnil(L); break;
             }

--- a/src/apis/fs.cpp
+++ b/src/apis/fs.cpp
@@ -427,13 +427,10 @@ static int fs_open(lua_State *L) {
             return 2;
         }
     }
-    std::fstream ** fp = NULL;
-    std::stringstream ** sfp = NULL;
     int fpid;
     if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:")) || path == ":bios.lua") {
         if (computer->files_open >= config.maximumFilesOpen) err(L, 1, "Too many files already open");
         std::stringstream ** fp = (std::stringstream**)lua_newuserdata(L, sizeof(std::stringstream**));
-        sfp = fp;
         fpid = lua_gettop(L);
 #ifdef STANDALONE_ROM
         if (path == ":bios.lua") {
@@ -474,7 +471,7 @@ static int fs_open(lua_State *L) {
             }
             fs::create_directories(path.parent_path());
         }
-        fp = (std::fstream**)lua_newuserdata(L, sizeof(std::fstream*));
+        std::fstream ** fp = (std::fstream**)lua_newuserdata(L, sizeof(std::fstream*));
         fpid = lua_gettop(L);
         std::ios::openmode flags;
         if (strchr(mode, 'r')) flags = std::ios::in;

--- a/src/apis/fs.cpp
+++ b/src/apis/fs.cpp
@@ -399,7 +399,7 @@ static int fs_open(lua_State *L) {
     lastCFunction = __func__;
     Computer * computer = get_comp(L);
     const char * mode = luaL_checkstring(L, 2);
-    if ((mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a') || (mode[1] != 'b' && mode[1] != '\0')) luaL_error(L, "%s: Unsupported mode", mode);
+    if ((mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a') || (!(mode[1] == 'b' && mode[2] == '\0') && mode[1] != '\0')) luaL_error(L, "%s: Unsupported mode", mode);
     std::string str = checkstring(L, 1);
     const path_t path = mode[0] == 'r' ? fixpath(get_comp(L), str, true) : fixpath_mkdir(get_comp(L), str);
     if (path.empty()) {
@@ -566,14 +566,6 @@ static int fs_open(lua_State *L) {
         lua_pushvalue(L, fpid);
         lua_pushcclosure(L, fs_handle_seek, 1);
         lua_settable(L, -3);
-    } else {
-        // This should now be unreachable, but we'll keep it here for safety
-        if (fp) {
-            (*fp)->close();
-            delete *fp;
-        } else if (sfp) delete *sfp;
-        lua_remove(L, fpid);
-        luaL_error(L, "%s: Unsupported mode", mode);
     }
     computer->files_open++;
     return 1;

--- a/src/apis/fs.cpp
+++ b/src/apis/fs.cpp
@@ -84,7 +84,7 @@ static std::vector<path_t> fixpath_multiple(Computer *comp, const std::string& p
     while (!pathc.empty() && pathc.front().empty()) pathc.pop_front();
     if (comp->isDebugger && pathc.size() == 1 && pathc.front() == "bios.lua")
 #ifdef STANDALONE_ROM
-        return {path_t(":bios.lua", path::format::generic_format)};
+        return {path_t(":bios.lua", path_t::format::generic_format)};
 #else
         return {getROMPath()/"bios.lua"};
 #endif

--- a/src/apis/fs.cpp
+++ b/src/apis/fs.cpp
@@ -85,7 +85,7 @@ static std::vector<path_t> fixpath_multiple(Computer *comp, const std::string& p
     while (!pathc.empty() && pathc.front().empty()) pathc.pop_front();
     if (comp->isDebugger && pathc.size() == 1 && pathc.front() == "bios.lua")
 #ifdef STANDALONE_ROM
-        return path_t(":bios.lua", path::format::generic_format);
+        return {path_t(":bios.lua", path::format::generic_format)};
 #else
         return {getROMPath()/"bios.lua"};
 #endif

--- a/src/apis/fs.cpp
+++ b/src/apis/fs.cpp
@@ -12,6 +12,8 @@
 #include <cstdio>
 #include <cstring>
 #include <codecvt>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <regex>
 #include <sstream>
@@ -35,7 +37,10 @@
 #define W_OK 2
 #endif
 
-#define err(L, idx, err) luaL_error(L, "/%s: %s", fixpath(get_comp(L), lua_tostring(L, idx), false, false).c_str(), err)
+using namespace std::filesystem;
+typedef std::basic_regex<path_t::value_type> pathregex;
+
+#define err(L, idx, err) luaL_error(L, "/%s: %s", fixpath(get_comp(L), lua_tostring(L, idx), false, false).string().c_str(), err)
 
 #ifdef STANDALONE_ROM
 extern FileEntry standaloneROM;
@@ -43,41 +48,94 @@ extern FileEntry standaloneDebug;
 extern std::string standaloneBIOS;
 #endif
 
-static path_t ignored_files[4] = {
-    WS("."),
-    WS(".."),
-    WS(".DS_Store"),
-    WS("desktop.ini")
+static path ignored_files[4] = {
+    ".",
+    "..",
+    ".DS_Store",
+    "desktop.ini"
 };
+
+static bool _nothrow(std::function<void()> f) { try { f(); return true; } catch (...) { return false; } }
+#define nothrow(expr) _nothrow([&](){ expr ;})
+
+inline bool isVFSPath(path_t path) {
+    if (!std::isdigit(path.native()[0])) return false;
+    for (const path_t::value_type& c : path.native()) {
+        if (c == ':') return true;
+        else if (!std::isdigit(c)) return false;
+    }
+    return false;
+}
+
+static std::vector<path_t> fixpath_multiple(Computer *comp, const std::string& path) {
+    std::vector<path_t> retval;
+    std::vector<std::string> elems = split(path, "/\\");
+    std::list<std::string> pathc;
+    for (std::string s : elems) {
+        if (s == "..") {
+            if (pathc.empty()) return retval;
+            else if (pathc.empty()) pathc.push_back("..");
+            else pathc.pop_back();
+        } else if (!s.empty() && !std::all_of(s.begin(), s.end(), [](const char c)->bool{return c == '.';})) {
+            s.erase(std::remove_if(s.begin(), s.end(), [](char c)->bool{return c=='"'||c==':'||c=='<'||c=='>'||c=='?'||c=='|';}), s.end());
+            pathc.push_back(s);
+        }
+    }
+    while (!pathc.empty() && pathc.front().empty()) pathc.pop_front();
+    if (comp->isDebugger && pathc.size() == 1 && pathc.front() == "bios.lua")
+#ifdef STANDALONE_ROM
+        return path_t(":bios.lua", path::format::generic_format);
+#else
+        return {getROMPath()/"bios.lua"};
+#endif
+    std::pair<size_t, std::vector<_path_t> > max_path = std::make_pair(0, std::vector<_path_t>(1, comp->dataDir));
+    std::list<std::string> * mount_list = NULL;
+    for (auto& m : comp->mounts) {
+        std::list<std::string> &pathlist = std::get<0>(m);
+        if (pathc.size() >= pathlist.size() && std::equal(pathlist.begin(), pathlist.end(), pathc.begin())) {
+            if (pathlist.size() > max_path.first) {
+                max_path = std::make_pair(pathlist.size(), std::vector<_path_t>(1, std::get<1>(m)));
+                mount_list = &pathlist;
+            } else if (pathlist.size() == max_path.first) {
+                max_path.second.push_back(std::get<1>(m));
+            }
+        }
+    }
+    for (size_t i = 0; i < max_path.first; i++) pathc.pop_front();
+    for (const _path_t& p : max_path.second) {
+        path_t sstmp = p;
+        for (const std::string& s : pathc) sstmp /= s;
+        if (
+            (isVFSPath(p) && nothrow(comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(sstmp.string()))) ||
+            (fs::exists(sstmp))) {
+            retval.push_back(sstmp);
+        }
+    }
+    return retval;
+}
 
 static int fs_list(lua_State *L) {
     lastCFunction = __func__;
-    struct_dirent *dir;
     std::string str = checkstring(L, 1);
-    const path_t paths = fixpath(get_comp(L), str, true, true, NULL, true);
-    if (paths.empty()) err(L, 1, "Not a directory");
-    std::vector<path_t> possible_paths = split(paths, WS("\n"));
+    const std::vector<path_t> possible_paths = fixpath_multiple(get_comp(L), str);
+    if (possible_paths.empty()) err(L, 1, "Not a directory");
     bool gotdir = false;
     std::set<std::string> entries;
     for (const path_t& path : possible_paths) {
-        if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
+        if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
             try {
-                const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));
+                const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));
                 gotdir = true;
                 if (d.isDir) for (const auto& p : d.dir) entries.insert(p.first);
                 else gotdir = false;
             } catch (...) {continue;}
         } else {
-            platform_DIR * d = platform_opendir(path.c_str());
-            if (d) {
+            if (fs::is_directory(path)) {
                 gotdir = true;
-                while ((dir = platform_readdir(d)) != NULL) {
-                    bool found = false;
-                    for (const path_t& ign : ignored_files) 
-                        if (pathcmp(dir->d_name, ign.c_str()) == 0) found = true;
-                    if (!found) entries.insert(astr(dir->d_name));
+                for (const auto& dir : fs::directory_iterator(path)) {
+                    if (dir.path().filename() == ".DS_Store" || dir.path().filename() == "desktop.ini") continue;
+                    entries.insert(dir.path().filename().string());
                 }
-                platform_closedir(d);
             }
         }
     }
@@ -98,12 +156,12 @@ static int fs_list(lua_State *L) {
 static int fs_exists(lua_State *L) {
     lastCFunction = __func__;
     const path_t path = fixpath(get_comp(L), checkstring(L, 1), true);
-    if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
         bool found = true;
-        try {get_comp(L)->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));} catch (...) {found = false;}
+        try {get_comp(L)->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));} catch (...) {found = false;}
         lua_pushboolean(L, found);
 #ifdef STANDALONE_ROM
-    } else if (path == WS(":bios.lua")) {
+    } else if (path == ":bios.lua") {
         lua_pushboolean(L, true);
 #endif
     } else {
@@ -119,12 +177,11 @@ static int fs_isDir(lua_State *L) {
         lua_pushboolean(L, false);
         return 1;
     }
-    if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
-        try {lua_pushboolean(L, get_comp(L)->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1)).isDir);} 
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
+        try {lua_pushboolean(L, get_comp(L)->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin())).isDir);} 
         catch (...) {lua_pushboolean(L, false);}
     } else {
-        struct_stat st;
-        lua_pushboolean(L, platform_stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode));
+        lua_pushboolean(L, fs::is_directory(path));
     }
     return 1;
 }
@@ -138,29 +195,26 @@ static int fs_isReadOnly(lua_State *L) {
     }
     const path_t path = fixpath_mkdir(get_comp(L), str, false);
     if (path.empty()) err(L, 1, "Invalid path"); // This should never happen
-    struct_stat st;
-    if (platform_stat(path.c_str(), &st) != 0) lua_pushboolean(L, false);
+    if (!fs::exists(path)) lua_pushboolean(L, false);
 #ifdef WIN32
-    else if (S_ISDIR(st.st_mode)) {
-        const path_t file = path + WS("\\a");
-        const bool didexist = platform_stat(file.c_str(), &st) == 0;
-        FILE * fp = platform_fopen(file.c_str(), "a");
-        lua_pushboolean(L, fp == NULL);
-        if (fp != NULL) fclose(fp);
-        if (!didexist && platform_stat(file.c_str(), &st) == 0) platform_remove(file.c_str());
+    else if (fs::is_directory(path)) {
+        const path_t file = path / "a";
+        const bool didexist = fs::exists(file);
+        std::ofstream fp(file, std::ios::app);
+        lua_pushboolean(L, fp.is_open());
+        fp.close();
+        if (!didexist && fs::exists(file)) fs::remove(file);
     }
 #endif
-    else lua_pushboolean(L, platform_access(path.c_str(), W_OK) != 0);
+    else lua_pushboolean(L, access(path.native().c_str(), W_OK) != 0);
     return 1;
 }
 
 static int fs_getName(lua_State *L) {
     lastCFunction = __func__;
-    luaL_checkstring(L, 1);
-    char * path = new char[lua_strlen(L, 1) + 1];
-    strcpy(path, lua_tostring(L, 1));
-    lua_pushstring(L, basename(path));
-    delete[] path;
+    std::string retval = path_t(checkstring(L, 1), path_t::generic_format).filename().string();
+    lua_pushlstring(L, retval.c_str(), retval.size());
+    //pushstring(L, retval);
     return 1;
 }
 
@@ -178,38 +232,27 @@ static int fs_getSize(lua_State *L) {
     std::string str = checkstring(L, 1);
     const path_t path = fixpath(get_comp(L), str, true);
     if (path.empty()) err(L, 1, "No such file");
-    if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
         try {
-            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));
+            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));
             if (d.isDir) err(L, 1, "Is a directory");
             lua_pushinteger(L, d.data.size());
         } catch (...) {err(L, 1, "No such file");}
 #ifdef STANDALONE_ROM
-    } else if (path == WS(":bios.lua")) {
+    } else if (path == ":bios.lua") {
         lua_pushinteger(L, standaloneBIOS.size());
 #endif
     } else {
-        struct_stat st;
-        if (platform_stat(path.c_str(), &st) != 0) err(L, 1, "No such file"); // redundant since v2.3?
-        lua_pushinteger(L, S_ISDIR(st.st_mode) ? 0 : st.st_size);
+        lua_pushinteger(L, fs::file_size(path));
     }
     return 1;
 }
 
 static int calculateDirectorySize(const path_t& path) {
-    platform_DIR * d = platform_opendir(path.c_str());
     int size = 0;
-    if (d) {
-        struct_dirent * dir;
-        struct_stat st;
-        while ((dir = platform_readdir(d)) != NULL) {
-            if (path_t(dir->d_name) != WS(".") && path_t(dir->d_name) != WS("..")) {
-                path_t dname = path + PATH_SEP + dir->d_name;
-                if (platform_stat(dname.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) size += calculateDirectorySize(dname);
-                else size += st.st_size;
-            }
-        }
-        platform_closedir(d);
+    for (const auto& dir : fs::directory_iterator(path)) {
+        if (dir.is_directory()) size += calculateDirectorySize(dir.path());
+        else size += dir.file_size();
     }
     return size;
 }
@@ -221,7 +264,7 @@ static int fs_getFreeSpace(lua_State *L) {
     const path_t path = fixpath(get_comp(L), str, false, true, &mountPath);
     if (path.empty()) err(L, 1, "No such path");
     if (fixpath_ro(get_comp(L), str)) lua_pushinteger(L, 0);
-    else if (!config.standardsMode || mountPath != "hdd") lua_pushinteger(L, getFreeSpace(path));
+    else if (!config.standardsMode || mountPath != "hdd") lua_pushinteger(L, fs::space(path).free);
     else lua_pushinteger(L, config.computerSpaceLimit - calculateDirectorySize(fixpath(get_comp(L), "", true)));
     return 1;
 }
@@ -232,9 +275,10 @@ static int fs_makeDir(lua_State *L) {
     if (fixpath_ro(get_comp(L), str)) err(L, 1, "Access denied");
     const path_t path = fixpath_mkdir(get_comp(L), str);
     if (path.empty()) err(L, 1, "Could not create directory");
-    struct_stat st;
-    if (platform_stat(path.c_str(), &st) == 0 && !S_ISDIR(st.st_mode)) err(L, 1, "File exists");
-    if (createDirectory(path) != 0 && errno != EEXIST) err(L, 1, strerror(errno));
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) err(L, 1, "Permission denied");
+    std::error_code e;
+    fs::create_directories(path, e);
+    if (e) err(L, 1, e.message().c_str());
     return 0;
 }
 
@@ -245,59 +289,17 @@ static int fs_move(lua_State *L) {
     if (fixpath_ro(get_comp(L), str1)) luaL_error(L, "Access denied");
     if (fixpath_ro(get_comp(L), str2)) luaL_error(L, "Access denied");
     bool isRoot = false;
-    const path_t fromPath = fixpath(get_comp(L), str1, true, true, NULL, false, &isRoot);
+    const path_t fromPath = fixpath(get_comp(L), str1, true, true, NULL, &isRoot);
     const path_t toPath = fixpath_mkdir(get_comp(L), str2);
     if (isRoot) luaL_error(L, "Cannot move mount");
     if (fromPath.empty()) err(L, 1, "No such file");
     if (toPath.empty()) err(L, 2, "Invalid path");
-    if (platform_rename(fromPath.c_str(), toPath.c_str()) != 0) err(L, 1, strerror(errno));
+    if (std::regex_search((*fromPath.begin()).native(), pathregex("^\\d+:"))) err(L, 1, "Permission denied");
+    if (std::regex_search((*toPath.begin()).native(), pathregex("^\\d+:"))) err(L, 2, "Permission denied");
+    std::error_code e;
+    fs::rename(fromPath, toPath, e);
+    if (e) err(L, 1, e.message().c_str());
     return 0;
-}
-
-std::pair<int, std::string> recursiveCopy(const path_t& fromPath, const path_t& toPath, std::list<path_t> * failures) {
-    struct_stat st;
-    if (failures == NULL && platform_stat(toPath.c_str(), &st) == 0) return std::make_pair(2, "File exists");
-    else if (platform_stat(fromPath.c_str(), &st) != 0) return std::make_pair(1, "No such file"); // likely redundant
-    else if (S_ISDIR(st.st_mode)) {
-        struct_dirent *dir;
-        platform_DIR * d = platform_opendir(fromPath.c_str());
-        if (d) {
-            createDirectory(toPath);
-            while ((dir = platform_readdir(d)) != NULL) {
-                bool found = false;
-                for (const path_t& ign : ignored_files)
-                    if (pathcmp(dir->d_name, ign.c_str()) == 0) found = true;
-                if (!found) {
-                    auto retval = recursiveCopy(fromPath + PATH_SEP + dir->d_name, toPath + PATH_SEP + dir->d_name, failures);
-                    if (retval.first > 0) {
-                        if (failures == NULL) return retval;
-                        failures->push_back(retval.first == 1 ? fromPath + PATH_SEP + dir->d_name : toPath + PATH_SEP + dir->d_name);
-                    }
-                }
-            }
-            platform_closedir(d);
-        } else return std::make_pair(1, "Cannot open directory");
-        return std::make_pair(0, "");
-    } else {
-        FILE * fromfp = platform_fopen(fromPath.c_str(), "rb");
-        if (fromfp == NULL) return std::make_pair(1, "Cannot read file");
-        FILE * tofp = platform_fopen(toPath.c_str(), "wb");
-        if (tofp == NULL) {
-            fclose(fromfp);
-            return std::make_pair(2, "Cannot write file");
-        }
-
-        char tmp[4096];
-        while (!feof(fromfp)) {
-            const size_t read = fread(tmp, 1, 4096, fromfp);
-            fwrite(tmp, read, 1, tofp);
-            if (read < 4096) break;
-        }
-
-        fclose(fromfp);
-        fclose(tofp);
-    }
-    return std::make_pair(0, "");
 }
 
 static int fs_copy(lua_State *L) {
@@ -309,14 +311,15 @@ static int fs_copy(lua_State *L) {
     const path_t toPath = fixpath_mkdir(get_comp(L), str2);
     if (fromPath.empty()) err(L, 1, "No such file");
     if (toPath.empty()) err(L, 2, "Invalid path");
-    if (std::regex_search(fromPath, pathregex(WS("^\\d+:")))) {
+    if (std::regex_search((*fromPath.begin()).native(), pathregex("^\\d+:"))) err(L, 2, "Permission denied");
+    if (std::regex_search((*toPath.begin()).native(), pathregex("^\\d+:"))) {
         try {
-            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul(fromPath.substr(0, fromPath.find_first_of(':')))]->path(fromPath.substr(fromPath.find_first_of(':') + 1));
+            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul((*fromPath.begin()).c_str())]->path(fromPath.lexically_relative(*fromPath.begin()));
             if (d.isDir) err(L, 1, "Is a directory");
-            FILE * tofp = platform_fopen(toPath.c_str(), "w");
-            if (tofp == NULL) return err(L, 2, "Cannot write file");
-            fwrite(d.data.c_str(), d.data.size(), 1, tofp);
-            fclose(tofp);
+            std::ofstream tofp(toPath);
+            if (!tofp.is_open()) return err(L, 2, "Cannot write file");
+            tofp.write(d.data.c_str(), d.data.size());
+            tofp.close();
         } catch (...) {err(L, 1, "No such file");}
     } else {
         /*if (isFSCaseSensitive == -1) {
@@ -342,8 +345,9 @@ static int fs_copy(lua_State *L) {
             else if ((i == fromElems.size() - 1 && i == toElems.size() - 1)) err(L, 1, "Can't copy a directory inside itself");
         }
         if (equal) err(L, 1, "Can't copy a directory inside itself");
-        const auto retval = recursiveCopy(fromPath, toPath);
-        if (retval.first != 0) err(L, retval.first, retval.second.c_str());
+        std::error_code e;
+        fs::copy(fromPath, toPath, fs::copy_options::recursive, e);
+        if (e) err(L, 1, e.message().c_str());
     }
     return 0;
 }
@@ -353,20 +357,25 @@ static int fs_delete(lua_State *L) {
     std::string str = checkstring(L, 1);
     if (fixpath_ro(get_comp(L), str)) err(L, 1, "Access denied");
     bool isRoot = false;
-    const path_t path = fixpath(get_comp(L), str, true, true, NULL, false, &isRoot);
+    const path_t path = fixpath(get_comp(L), str, true, true, NULL, &isRoot);
     if (isRoot) luaL_error(L, "Cannot delete mount, use mounter.unmount instead");
     if (path.empty()) return 0;
-    const int res = removeDirectory(path);
-    if (res != 0 && res != ENOENT) err(L, 1, "Failed to remove");
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) err(L, 1, "Permission denied");
+    std::error_code e;
+    fs::remove_all(path, e);
+    if (e) err(L, 1, e.message().c_str());
     return 0;
 }
 
 static int fs_combine(lua_State *L) {
     lastCFunction = __func__;
-    std::string basePath = checkstring(L, 1);
-    for (int i = 2; i <= lua_gettop(L); i++) basePath += "/" + checkstring(L, i);
-    basePath = astr(fixpath(get_comp(L), basePath, false, false));
-    lua_pushlstring(L, basePath.c_str(), basePath.size());
+    path_t basePath = path_t(checkstring(L, 1), path_t::generic_format);
+    for (int i = 2; i <= lua_gettop(L); i++) if (!checkstring(L, i).empty()) basePath += "/" + tostring(L, i);
+    if (basePath.is_absolute()) basePath = basePath.lexically_relative("/");
+    else basePath = basePath.lexically_normal();
+    std::string str = basePath.string();
+    lua_pushlstring(L, str.c_str(), str.size());
+    //pushstring(L, str);
     return 1;
 }
 
@@ -380,37 +389,37 @@ static int fs_open(lua_State *L) {
     if (path.empty()) {
         if (mode[0] != 'r' && fixpath_ro(computer, str)) {
             lua_pushnil(L);
-            lua_pushfstring(L, "/%s: Access denied", astr(fixpath(computer, str, false, false)).c_str());
+            lua_pushfstring(L, "/%s: Access denied", fixpath(computer, str, false, false).string().c_str());
             return 2;
         } else {
             lua_pushnil(L);
-            lua_pushfstring(L, "/%s: No such file", astr(fixpath(computer, str, false, false)).c_str());
+            lua_pushfstring(L, "/%s: No such file", fixpath(computer, str, false, false).string().c_str());
             return 2;
         }
     }
-    if (std::regex_search(path, pathregex(WS("^\\d+:"))) || path == WS(":bios.lua")) {
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:")) || path == ":bios.lua") {
         if (computer->files_open >= config.maximumFilesOpen) err(L, 1, "Too many files already open");
         std::stringstream ** fp = (std::stringstream**)lua_newuserdata(L, sizeof(std::stringstream**));
         int fpid = lua_gettop(L);
 #ifdef STANDALONE_ROM
-        if (path == WS(":bios.lua")) {
+        if (path == ":bios.lua") {
             *fp = new std::stringstream(standaloneBIOS);
         } else {
 #endif
             try {
-                const FileEntry &d = computer->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));
+                const FileEntry &d = computer->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));
                 if (d.isDir) {
                     lua_remove(L, fpid);
                     lua_pushnil(L);
-                    if (strcmp(mode, "r") == 0 || strcmp(mode, "rb") == 0) lua_pushfstring(L, "/%s: No such file", astr(fixpath(computer, str, false, false)).c_str());
-                    else lua_pushfstring(L, "/%s: Cannot write to directory", astr(fixpath(computer, str, false, false)).c_str());
+                    if (strcmp(mode, "r") == 0 || strcmp(mode, "rb") == 0) lua_pushfstring(L, "/%s: No such file", fixpath(computer, str, false, false).string().c_str());
+                    else lua_pushfstring(L, "/%s: Cannot write to directory", fixpath(computer, str, false, false).string().c_str());
                     return 2; 
                 }
                 *fp = new std::stringstream(d.data);
             } catch (...) {
                 lua_remove(L, fpid);
                 lua_pushnil(L);
-                lua_pushfstring(L, "/%s: No such file", astr(fixpath(computer, str, false, false)).c_str());
+                lua_pushfstring(L, "/%s: No such file", fixpath(computer, str, false, false).string().c_str());
                 return 2;
             }
 #ifdef STANDALONE_ROM
@@ -420,89 +429,90 @@ static int fs_open(lua_State *L) {
             lua_createtable(L, 0, 4);
             lua_pushstring(L, "close");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_close, 1);
+            lua_pushcclosure(L, fs_handle_close, 1);
             lua_settable(L, -3);
 
             lua_pushstring(L, "readAll");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_readAll, 1);
+            lua_pushcclosure(L, fs_handle_readAll, 1);
             lua_settable(L, -3);
 
             lua_pushstring(L, "readLine");
             lua_pushvalue(L, fpid);
             lua_pushboolean(L, false);
-            lua_pushcclosure(L, fs_handle_istream_readLine, 2);
+            lua_pushcclosure(L, fs_handle_readLine, 2);
             lua_settable(L, -3);
 
             lua_pushstring(L, "read");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_readChar, 1);
+            lua_pushcclosure(L, fs_handle_readChar, 1);
             lua_settable(L, -3);
         } else if (strcmp(mode, "rb") == 0) {
             lua_createtable(L, 0, 5);
             lua_pushstring(L, "close");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_close, 1);
+            lua_pushcclosure(L, fs_handle_close, 1);
             lua_settable(L, -3);
 
             lua_pushstring(L, "read");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_readByte, 1);
+            lua_pushcclosure(L, fs_handle_readByte, 1);
             lua_settable(L, -3);
 
             lua_pushstring(L, "readAll");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_readAllByte, 1);
+            lua_pushcclosure(L, fs_handle_readAllByte, 1);
             lua_settable(L, -3);
 
             lua_pushstring(L, "readLine");
             lua_pushvalue(L, fpid);
             lua_pushboolean(L, true);
-            lua_pushcclosure(L, fs_handle_istream_readLine, 2);
+            lua_pushcclosure(L, fs_handle_readLine, 2);
             lua_settable(L, -3);
 
             lua_pushstring(L, "seek");
             lua_pushvalue(L, fpid);
-            lua_pushcclosure(L, fs_handle_istream_seek, 1);
+            lua_pushcclosure(L, fs_handle_seek, 1);
             lua_settable(L, -3);
         } else {
             lua_remove(L, fpid);
             lua_pushnil(L);
-            lua_pushfstring(L, "/%s: Access denied", astr(fixpath(computer, str, false, false)).c_str());
+            lua_pushfstring(L, "/%s: Access denied", fixpath(computer, str, false, false).string().c_str());
             return 2; 
         }
     } else {
-        struct_stat st;
-        if (platform_stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) { 
+        if (fs::is_directory(path)) { 
             lua_pushnil(L);
-            if (strcmp(mode, "r") == 0 || strcmp(mode, "rb") == 0) lua_pushfstring(L, "/%s: No such file", astr(fixpath(computer, str, false, false)).c_str());
-            else lua_pushfstring(L, "/%s: Cannot write to directory", astr(fixpath(computer, str, false, false)).c_str());
+            if (strcmp(mode, "r") == 0 || strcmp(mode, "rb") == 0) lua_pushfstring(L, "/%s: No such file", fixpath(computer, str, false, false).string().c_str());
+            else lua_pushfstring(L, "/%s: Cannot write to directory", fixpath(computer, str, false, false).string().c_str());
             return 2; 
         }
         if (strcmp(mode, "w") == 0 || strcmp(mode, "a") == 0 || strcmp(mode, "wb") == 0 || strcmp(mode, "ab") == 0) {
             if (fixpath_ro(computer, str)) {
                 lua_pushnil(L);
-                lua_pushfstring(L, "/%s: Access denied", astr(fixpath(computer, str, false, false)).c_str());
+                lua_pushfstring(L, "/%s: Access denied", fixpath(computer, str, false, false).string().c_str());
                 return 2; 
             }
-    #ifdef WIN32
-            createDirectory(path.substr(0, path.find_last_of('\\')));
-    #else
-            createDirectory(path.substr(0, path.find_last_of('/')));
-    #endif
+            fs::create_directories(path.parent_path());
         }
-        FILE ** fp = (FILE**)lua_newuserdata(L, sizeof(FILE*));
+        std::fstream ** fp = (std::fstream**)lua_newuserdata(L, sizeof(std::fstream*));
         int fpid = lua_gettop(L);
-        if (mode[1] != 'b') *fp = platform_fopen(path.c_str(), (std::string(mode) + 'b').c_str());
-        else *fp = platform_fopen(path.c_str(), mode);
-        if (*fp == NULL) { 
+        std::ios::openmode flags;
+        if (strchr(mode, 'r')) flags = std::ios::in;
+        else if (strchr(mode, 'w')) flags = std::ios::out | std::ios::trunc;
+        else if (strchr(mode, 'a')) flags = std::ios::in | std::ios::out | std::ios::ate;
+        if (strchr(mode, 'b')) flags |= std::ios::binary;
+        *fp = new std::fstream(path, flags);
+        if (!(*fp)->is_open()) { 
+            delete *fp;
             lua_remove(L, fpid);
             lua_pushnil(L);
-            lua_pushfstring(L, "/%s: No such file", astr(fixpath(computer, str, false, false)).c_str());
+            lua_pushfstring(L, "/%s: No such file", fixpath(computer, str, false, false).native().c_str());
             return 2; 
         }
         if (computer->files_open >= config.maximumFilesOpen) {
-            fclose(*fp);
+            (*fp)->close();
+            delete *fp;
             err(L, 1, "Too many files already open");
         }
         lua_createtable(L, 0, 4);
@@ -579,7 +589,8 @@ static int fs_open(lua_State *L) {
             lua_settable(L, -3);
         } else {
             // This should now be unreachable, but we'll keep it here for safety
-            fclose(*fp);
+            (*fp)->close();
+            delete *fp;
             lua_remove(L, fpid);
             luaL_error(L, "%s: Unsupported mode", mode);
         }
@@ -606,27 +617,20 @@ static std::list<std::string> matchWildcard(Computer * comp, const std::list<std
     pathc_regex = replace_str(pathc_regex, "*", ".*");
     std::list<std::string> nextOptions;
     for (const std::string& opt : options) {
-        struct_dirent *dir;
-        path_t paths = fixpath(comp, opt.c_str(), true, true, NULL, true);
-        if (paths.empty()) continue;
-        std::vector<path_t> possible_paths = split(paths, WS("\n"));
+        std::vector<path_t> possible_paths = fixpath_multiple(comp, opt.c_str());
+        if (possible_paths.empty()) continue;
         for (const path_t& path : possible_paths) {
-            if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
+            if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
                 try {
-                    const FileEntry &d = comp->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));
+                    const FileEntry &d = comp->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));
                     if (d.isDir) for (auto p : d.dir) if (std::regex_match(p.first, std::regex(pathc_regex))) nextOptions.push_back(opt + (opt == "" ? "" : "/") + p.first);
                 } catch (...) {continue;}
             } else {
-                platform_DIR * d = platform_opendir(path.c_str());
-                if (d) {
-                    for (int i = 0; (dir = platform_readdir(d)) != NULL; i++) {
-                        int found = 0;
-                        for (const path_t& ign : ignored_files)
-                            if (pathcmp(dir->d_name, ign.c_str()) == 0) { i--; found = 1; }
-                        if (found) continue;
-                        if (std::regex_match(std::string(astr(dir->d_name)), std::regex(pathc_regex))) nextOptions.push_back(opt + (opt.empty() ? "" : "/") + std::string(astr(dir->d_name)));
+                if (fs::is_directory(path)) {
+                    for (const auto& dir : fs::directory_iterator(path)) {
+                        if (dir.path().filename() == ".DS_Store" || dir.path().filename() == "desktop.ini") continue;
+                        if (std::regex_match(dir.path().filename().string(), std::regex(pathc_regex))) nextOptions.push_back(opt + (opt.empty() ? "" : "/") + dir.path().filename().string());
                     }
-                    platform_closedir(d);
                 }
             }
         }
@@ -672,9 +676,13 @@ static int fs_find(lua_State *L) {
 
 static int fs_getDir(lua_State *L) {
     lastCFunction = __func__;
-    std::string str = checkstring(L, 1);
-    std::string path = astr(fixpath(get_comp(L), str + "/..", false, false));
-    lua_pushlstring(L, path.c_str(), path.size());
+    path_t path = path_t(checkstring(L, 1));
+    path = path.parent_path();
+    if (path.is_absolute()) path = path.lexically_relative("/");
+    else path = path.lexically_normal();
+    std::string str = path.string();
+    lua_pushlstring(L, str.c_str(), str.size());
+    //pushstring(L, path.string());
     return 1;
 }
 
@@ -691,9 +699,9 @@ static int fs_attributes(lua_State *L) {
     std::string str = checkstring(L, 1);
     const path_t path = fixpath(get_comp(L), str, true);
     if (path.empty()) err(L, 1, "No such file");
-    if (std::regex_search(path, pathregex(WS("^\\d+:")))) {
+    if (std::regex_search((*path.begin()).native(), pathregex("^\\d+:"))) {
         try {
-            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul(path.substr(0, path.find_first_of(':')))]->path(path.substr(path.find_first_of(':') + 1));
+            const FileEntry &d = get_comp(L)->virtualMounts[(unsigned)std::stoul((*path.begin()).native())]->path(path.lexically_relative(*path.begin()));
             lua_createtable(L, 0, 6);
             lua_pushinteger(L, 0);
             lua_setfield(L, -2, "modification");
@@ -712,11 +720,19 @@ static int fs_attributes(lua_State *L) {
             return 1;
         }
     } else {
-        struct_stat st;
-        if (platform_stat(path.c_str(), &st) != 0) {
+#ifdef _WIN32
+        struct wstat st;
+        if (_wstat(path.c_str(), &st) != 0) {
             lua_pushnil(L);
             return 1;
         }
+#else
+        struct stat st;
+        if (stat(path.c_str(), &st) != 0) {
+            lua_pushnil(L);
+            return 1;
+        }
+#endif
         lua_createtable(L, 0, 6);
         lua_pushinteger(L, st_time_ms(st.st_m));
         lua_setfield(L, -2, "modification");
@@ -730,19 +746,18 @@ static int fs_attributes(lua_State *L) {
         lua_setfield(L, -2, "isDir");
         if (fixpath_ro(get_comp(L), str)) lua_pushboolean(L, true);
         else {
-            struct_stat st;
-            if (platform_stat(path.c_str(), &st) != 0) lua_pushboolean(L, false);
-        #ifdef WIN32
-            else if (S_ISDIR(st.st_mode)) {
-                const path_t file = path + WS("\\a");
-                const bool didexist = platform_stat(file.c_str(), &st) == 0;
-                FILE * fp = platform_fopen(file.c_str(), "a");
-                lua_pushboolean(L, fp == NULL);
-                if (fp != NULL) fclose(fp);
-                if (!didexist && platform_stat(file.c_str(), &st) == 0) platform_remove(file.c_str());
+            if (!fs::exists(path)) lua_pushboolean(L, false);
+#ifdef WIN32
+            else if (fs::is_directory(path)) {
+                const path_t file = path / "a";
+                const bool didexist = fs::exists(file);
+                std::ofstream fp(file, std::ios::app);
+                lua_pushboolean(L, fp.is_open());
+                fp.close();
+                if (!didexist && fs::exists(file)) fs::remove(file);
             }
-        #endif
-            else lua_pushboolean(L, platform_access(path.c_str(), W_OK) != 0);
+#endif
+            else lua_pushboolean(L, access(path.native().c_str(), W_OK) != 0);
         }
         lua_setfield(L, -2, "isReadOnly");
     }
@@ -762,7 +777,7 @@ static int fs_getCapacity(lua_State *L) {
         return 1;
     }
     if (path.empty()) luaL_error(L, "%s: Invalid path", str.c_str());
-    lua_pushinteger(L, getCapacity(path));
+    lua_pushinteger(L, fs::space(path).capacity);
     return 1;
 }
 
@@ -770,7 +785,7 @@ static int fs_isDriveRoot(lua_State *L) {
     lastCFunction = __func__;
     bool res = false;
     std::string str = checkstring(L, 1);
-    fixpath(get_comp(L), str, false, true, NULL, false, &res);
+    fixpath(get_comp(L), str, false, true, NULL, &res);
     lua_pushboolean(L, res);
     return 1;
 }

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -60,7 +60,7 @@ int fs_handle_readAll(lua_State *L) {
     int i;
     for (i = 0; !fp->eof() && i < size; i++) {
         int c = fp->get();
-        if (c == EOF && fp->eof()) break;
+        if (c == EOF && fp->eof()) continue;
         if (c == '\n' && (i > 0 && retval[i-1] == '\r')) retval[--i] = '\n';
         else retval[i] = (char)c;
     }

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <codecvt>
+#include <iostream>
 #include <locale>
 #include <string>
 #include "fs_handle.hpp"
@@ -34,23 +35,10 @@ EM_JS(void, syncfs, (), {
 
 int fs_handle_close(lua_State *L) {
     lastCFunction = __func__;
-    if (*(FILE**)lua_touserdata(L, lua_upvalueindex(1)) == NULL)
+    if (*(std::iostream**)lua_touserdata(L, lua_upvalueindex(1)) == NULL)
         return luaL_error(L, "attempt to use a closed file");
-    fclose(*(FILE**)lua_touserdata(L, lua_upvalueindex(1)));
-    *(FILE**)lua_touserdata(L, lua_upvalueindex(1)) = NULL;
-    get_comp(L)->files_open--;
-#ifdef __EMSCRIPTEN__
-    queueTask([](void*)->void*{syncfs(); return NULL;}, NULL, true);
-#endif
-    return 0;
-}
-
-int fs_handle_istream_close(lua_State *L) {
-    lastCFunction = __func__;
-    if (*(std::istream**)lua_touserdata(L, lua_upvalueindex(1)) == NULL)
-        return luaL_error(L, "attempt to use a closed file");
-    delete *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
-    *(std::istream**)lua_touserdata(L, lua_upvalueindex(1)) = NULL;
+    delete *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
+    *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1)) = NULL;
     get_comp(L)->files_open--;
 #ifdef __EMSCRIPTEN__
     queueTask([](void*)->void*{syncfs(); return NULL;}, NULL, true);
@@ -60,31 +48,7 @@ int fs_handle_istream_close(lua_State *L) {
 
 int fs_handle_readAll(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    if (feof(fp)) return 0;
-    const long pos = ftell(fp);
-    fseek(fp, 0, SEEK_END);
-    const long size = ftell(fp) - pos;
-    char * retval = new char[size + 1];
-    memset(retval, 0, size + 1);
-    fseek(fp, pos, SEEK_SET);
-    int i;
-    for (i = 0; !feof(fp) && i < size; i++) {
-        int c = fgetc(fp);
-        if (c == EOF && feof(fp)) c = '\n';
-        if (c == '\n' && (i > 0 && retval[i-1] == '\r')) retval[--i] = '\n';
-        else retval[i] = (char)c;
-    }
-    const std::string out = makeASCIISafe(retval, i - (i == size ? 0 : 1));
-    delete[] retval;
-    lua_pushlstring(L, out.c_str(), out.length());
-    return 1;
-}
-
-int fs_handle_istream_readAll(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     if (fp->eof()) return 0;
     const long pos = (long)fp->tellg();
@@ -108,35 +72,7 @@ int fs_handle_istream_readAll(lua_State *L) {
 
 int fs_handle_readLine(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    if (feof(fp) || ferror(fp)) return 0;
-    char* retval = (char*)malloc(256);
-    retval[0] = 0;
-    for (unsigned i = 0; true; i += 255) {
-        if (fgets(&retval[i], 256, fp) == NULL || feof(fp)) break;
-        bool found = false;
-        for (unsigned j = 0; j < 256; j++) if (retval[i+j] == '\n') {found = true; break;}
-        if (found) break;
-        char * retvaln = (char*)realloc(retval, i + 511);
-        if (retvaln == NULL) {
-            free(retval);
-            return luaL_error(L, "failed to allocate memory");
-        }
-        retval = retvaln;
-    }
-    size_t len = strlen(retval) - (strlen(retval) > 0 && retval[strlen(retval)-1] == '\n' && !lua_toboolean(L, 1));
-    if (len == 0 && feof(fp)) {free(retval); return 0;}
-    if (len > 0 && retval[len-1] == '\r') retval[--len] = '\0';
-    const std::string out = lua_toboolean(L, lua_upvalueindex(2)) ? std::string(retval, len) : makeASCIISafe(retval, len);
-    free(retval);
-    lua_pushlstring(L, out.c_str(), out.length());
-    return 1;
-}
-
-int fs_handle_istream_readLine(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     if (fp->bad() || fp->eof()) return 0;
     std::string retval;
@@ -151,52 +87,7 @@ int fs_handle_istream_readLine(lua_State *L) {
 
 int fs_handle_readChar(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    if (feof(fp)) return 0;
-    std::string retval;
-    for (int i = 0; i < (lua_isnumber(L, 1) ? lua_tointeger(L, 1) : 1) && !feof(fp); i++) {
-        uint32_t codepoint;
-        const int c = fgetc(fp);
-        if (c == EOF) break;
-        else if (c < 0) {
-            if (c & 64) {
-                const int c2 = fgetc(fp);
-                if (c2 == EOF) {retval += '?'; break;}
-                else if (c2 >= 0 || c2 & 64) codepoint = 1U<<31;
-                else if (c & 32) {
-                    const int c3 = fgetc(fp);
-                    if (c3 == EOF) {retval += '?'; break;}
-                    else if (c3 >= 0 || c3 & 64) codepoint = 1U<<31;
-                    else if (c & 16) {
-                        if (c & 8) codepoint = 1U<<31;
-                        else {
-                            const int c4 = fgetc(fp);
-                            if (c4 == EOF) {retval += '?'; break;}
-                            else if (c4 >= 0 || c4 & 64) codepoint = 1U<<31;
-                            else codepoint = ((c & 0x7) << 18) | ((c2 & 0x3F) << 12) | ((c3 & 0x3F) << 6) | (c4 & 0x3F);
-                        }
-                    } else codepoint = ((c & 0xF) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F);
-                } else codepoint = ((c & 0x1F) << 6) | (c2 & 0x3F);
-            } else codepoint = 1U<<31;
-        } else codepoint = (unsigned char)c;
-        if (codepoint > 255) retval += '?';
-        else {
-            if (codepoint == '\r') {
-                const int nextc = fgetc(fp);
-                if (nextc == '\n') codepoint = nextc;
-                else ungetc(nextc, fp);
-            }
-            retval += (unsigned char)codepoint;
-        }
-    }
-    lua_pushlstring(L, retval.c_str(), retval.length());
-    return 1;
-}
-
-int fs_handle_istream_readChar(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     if (fp->eof()) return 0;
     std::string retval;
@@ -241,34 +132,7 @@ int fs_handle_istream_readChar(lua_State *L) {
 
 int fs_handle_readByte(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    if (feof(fp)) return 0;
-    if (lua_isnumber(L, 1)) {
-        const size_t s = lua_tointeger(L, 1);
-        if (s == 0) {
-            const int c = fgetc(fp);
-            if (c == EOF || feof(fp)) return 0;
-            ungetc(c, fp);
-            lua_pushstring(L, "");
-            return 1;
-        }
-        char* retval = new char[s];
-        const size_t actual = fread(retval, 1, s, fp);
-        if (actual == 0 && feof(fp)) {delete[] retval; return 0;}
-        lua_pushlstring(L, retval, actual);
-        delete[] retval;
-    } else {
-        const int retval = fgetc(fp);
-        if (retval == EOF || feof(fp)) return 0;
-        lua_pushinteger(L, (unsigned char)retval);
-    }
-    return 1;
-}
-
-int fs_handle_istream_readByte(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     if (fp->eof()) return 0;
     if (lua_isnumber(L, 1)) {
@@ -293,30 +157,7 @@ int fs_handle_istream_readByte(lua_State *L) {
 
 int fs_handle_readAllByte(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    if (feof(fp)) return 0;
-    size_t size = 0;
-    char * str = (char*)malloc(512);
-    if (str == NULL) return luaL_error(L, "failed to allocate memory");
-    while (!feof(fp)) {
-        size += fread(&str[size], 1, 512, fp);
-        if (size % 512 != 0) break;
-        char * strn = (char*)realloc(str, size + 512);
-        if (strn == NULL) {
-            free(str);
-            return luaL_error(L, "failed to allocate memory");
-        }
-        str = strn;
-    }
-    lua_pushlstring(L, str, size);
-    free(str);
-    return 1;
-}
-
-int fs_handle_istream_readAllByte(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     if (fp->eof()) return 0;
     size_t size = 0;
@@ -339,7 +180,7 @@ int fs_handle_istream_readAllByte(lua_State *L) {
 
 int fs_handle_writeString(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) luaL_error(L, "attempt to use a closed file");
     if (lua_isnoneornil(L, 1)) return 0;
     else if (!lua_isstring(L, 1) && !lua_isnumber(L, 1)) luaL_typerror(L, 1, "string");
@@ -348,13 +189,13 @@ int fs_handle_writeString(lua_State *L) {
     for (unsigned char c : str) wstr += (wchar_t)c;
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
     const std::string newstr = converter.to_bytes(wstr);
-    fwrite(newstr.c_str(), newstr.size(), 1, fp);
+    fp->write(newstr.c_str(), newstr.size());
     return 0;
 }
 
 int fs_handle_writeLine(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) luaL_error(L, "attempt to use a closed file");
     if (lua_isnoneornil(L, 1)) return 0;
     else if (!lua_isstring(L, 1) && !lua_isnumber(L, 1)) luaL_typerror(L, 1, "string");
@@ -363,59 +204,41 @@ int fs_handle_writeLine(lua_State *L) {
     for (unsigned char c : str) wstr += (wchar_t)c;
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
     const std::string newstr = converter.to_bytes(wstr);
-    fwrite(newstr.c_str(), newstr.size(), 1, fp);
-    fputc('\n', fp);
+    fp->write(newstr.c_str(), newstr.size());
+    fp->put('\n');
     return 0;
 }
 
 int fs_handle_writeByte(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) luaL_error(L, "attempt to use a closed file");
     if (lua_type(L, 1) == LUA_TNUMBER) {
         const char b = (unsigned char)(lua_tointeger(L, 1) & 0xFF);
-        fputc(b, fp);
+        fp->put(b);
     } else if (lua_isstring(L, 1)) {
-        if (lua_strlen(L, 1) == 0) return 0;
-        fwrite(lua_tostring(L, 1), lua_strlen(L, 1), 1, fp);
+        size_t sz = 0;
+        const char * str = lua_tolstring(L, 1, &sz);
+        if (sz == 0) return 0;
+        fp->write(str, sz);
     } else luaL_typerror(L, 1, "number or string");
     return 0;
 }
 
 int fs_handle_flush(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    fflush(fp);
-    #ifdef __EMSCRIPTEN__
+    fp->flush();
+#ifdef __EMSCRIPTEN__
     queueTask([](void*)->void*{syncfs(); return NULL;}, NULL, true);
-    #endif
+#endif
     return 0;
 }
 
 int fs_handle_seek(lua_State *L) {
     lastCFunction = __func__;
-    FILE * fp = *(FILE**)lua_touserdata(L, lua_upvalueindex(1));
-    if (fp == NULL) luaL_error(L, "attempt to use a closed file");
-    const char * whence = luaL_optstring(L, 1, "cur");
-    const long offset = (long)luaL_optinteger(L, 2, 0);
-    int origin = 0;
-    if (strcmp(whence, "set") == 0) origin = SEEK_SET;
-    else if (strcmp(whence, "cur") == 0) origin = SEEK_CUR;
-    else if (strcmp(whence, "end") == 0) origin = SEEK_END;
-    else luaL_error(L, "bad argument #1 to 'seek' (invalid option '%s')", whence);
-    if (fseek(fp, offset, origin) != 0) {
-        lua_pushnil(L);
-        lua_pushstring(L, strerror(errno));
-        return 2;
-    }
-    lua_pushinteger(L, ftell(fp));
-    return 1;
-}
-
-int fs_handle_istream_seek(lua_State *L) {
-    lastCFunction = __func__;
-    std::istream * fp = *(std::istream**)lua_touserdata(L, lua_upvalueindex(1));
+    std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
     if (fp == NULL) return luaL_error(L, "attempt to use a closed file");
     const char * whence = luaL_optstring(L, 1, "cur");
     const size_t offset = luaL_optinteger(L, 2, 0);

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -53,14 +53,14 @@ int fs_handle_readAll(lua_State *L) {
     if (fp->eof()) return 0;
     const long pos = (long)fp->tellg();
     fp->seekg(0, std::ios::end);
-    const long size = (long)fp->tellg() - pos;
+    long size = (long)fp->tellg() - pos;
     char * retval = new char[size + 1];
     memset(retval, 0, size + 1);
     fp->seekg(pos);
     int i;
     for (i = 0; !fp->eof() && i < size; i++) {
         int c = fp->get();
-        if (c == EOF && fp->eof()) continue;
+        if (c == EOF && fp->eof()) { size = i; break; }
         if (c == '\n' && (i > 0 && retval[i-1] == '\r')) retval[--i] = '\n';
         else retval[i] = (char)c;
     }

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -60,7 +60,6 @@ int fs_handle_readAll(lua_State *L) {
     int i;
     for (i = 0; !fp->eof() && i < size; i++) {
         int c = fp->get();
-        if (c == EOF && fp->eof()) c = '\n';
         if (c == '\n' && (i > 0 && retval[i-1] == '\r')) retval[--i] = '\n';
         else retval[i] = (char)c;
     }

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -60,6 +60,7 @@ int fs_handle_readAll(lua_State *L) {
     int i;
     for (i = 0; !fp->eof() && i < size; i++) {
         int c = fp->get();
+        if (c == EOF && fp->eof()) break;
         if (c == '\n' && (i > 0 && retval[i-1] == '\r')) retval[--i] = '\n';
         else retval[i] = (char)c;
     }

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -46,6 +46,19 @@ int fs_handle_close(lua_State *L) {
     return 0;
 }
 
+int fs_handle_gc(lua_State *L) {
+    lastCFunction = __func__;
+    if (*(std::iostream**)lua_touserdata(L, lua_upvalueindex(1)) == NULL)
+        return 0;
+    delete *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));
+    *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1)) = NULL;
+    get_comp(L)->files_open--;
+#ifdef __EMSCRIPTEN__
+    queueTask([](void*)->void*{syncfs(); return NULL;}, NULL, true);
+#endif
+    return 0;
+}
+
 int fs_handle_readAll(lua_State *L) {
     lastCFunction = __func__;
     std::iostream * fp = *(std::iostream**)lua_touserdata(L, lua_upvalueindex(1));

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -143,7 +143,8 @@ int fs_handle_readByte(lua_State *L) {
             return 1;
         }
         char* retval = new char[s];
-        const size_t actual = fp->readsome(retval, s);
+        fp->read(retval, s);
+        const size_t actual = fp->gcount();
         if (actual == 0) {delete[] retval; return 0;}
         lua_pushlstring(L, retval, actual);
         delete[] retval;
@@ -164,7 +165,8 @@ int fs_handle_readAllByte(lua_State *L) {
     char * str = (char*)malloc(512);
     if (str == NULL) return luaL_error(L, "failed to allocate memory");
     while (!fp->eof()) {
-        size += fp->readsome(&str[size], 512);
+        fp->read(&str[size], 512);
+        size += fp->gcount();
         if (size % 512 != 0) break;
         char * strn = (char*)realloc(str, size + 512);
         if (strn == NULL) {

--- a/src/apis/handles/fs_handle.cpp
+++ b/src/apis/handles/fs_handle.cpp
@@ -99,9 +99,9 @@ int fs_handle_readLine(lua_State *L) {
     std::string retval;
     std::getline(*fp, retval);
     if (retval.empty() && fp->eof()) return 0;
-    size_t len = retval.length() - (retval[retval.length()-1] == '\n' && !lua_toboolean(L, 1));
-    if (len > 0 && retval[len-1] == '\r') {if (lua_toboolean(L, 1)) {retval[len] = '\0'; retval[--len] = '\n';} else retval[--len] = '\0';}
-    const std::string out = lua_toboolean(L, lua_upvalueindex(2)) ? std::string(retval, 0, len) : makeASCIISafe(retval.c_str(), len);
+    if (*retval.rbegin() == '\r' && !lua_toboolean(L, lua_upvalueindex(2))) retval = retval.substr(0, retval.size()-1);
+    if (lua_toboolean(L, 1) && fp->good()) retval += '\n';
+    const std::string out = lua_toboolean(L, lua_upvalueindex(2)) ? retval : makeASCIISafe(retval.c_str(), retval.size());
     lua_pushlstring(L, out.c_str(), out.length());
     return 1;
 }

--- a/src/apis/handles/fs_handle.hpp
+++ b/src/apis/handles/fs_handle.hpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <lua.h>
 }
 extern int fs_handle_close(lua_State *L);
+extern int fs_handle_gc(lua_State *L);
 extern int fs_handle_readAll(lua_State *L);
 extern int fs_handle_readLine(lua_State *L);
 extern int fs_handle_readChar(lua_State *L);

--- a/src/apis/handles/fs_handle.hpp
+++ b/src/apis/handles/fs_handle.hpp
@@ -19,16 +19,9 @@ extern int fs_handle_readLine(lua_State *L);
 extern int fs_handle_readChar(lua_State *L);
 extern int fs_handle_readByte(lua_State *L);
 extern int fs_handle_readAllByte(lua_State *L);
-extern int fs_handle_istream_close(lua_State *L);
-extern int fs_handle_istream_readAll(lua_State *L);
-extern int fs_handle_istream_readLine(lua_State *L);
-extern int fs_handle_istream_readChar(lua_State *L);
-extern int fs_handle_istream_readByte(lua_State *L);
-extern int fs_handle_istream_readAllByte(lua_State *L);
 extern int fs_handle_writeString(lua_State *L);
 extern int fs_handle_writeLine(lua_State *L);
 extern int fs_handle_writeByte(lua_State *L);
 extern int fs_handle_flush(lua_State *L);
 extern int fs_handle_seek(lua_State *L);
-extern int fs_handle_istream_seek(lua_State *L);
 #endif

--- a/src/apis/handles/http_handle.cpp
+++ b/src/apis/handles/http_handle.cpp
@@ -171,7 +171,7 @@ int http_handle_readAllByte(lua_State *L) {
     while (handle->stream->read(buffer, sizeof(buffer)))
         ret.append(buffer, sizeof(buffer));
     ret.append(buffer, handle->stream->gcount());
-    lua_pushlstring(L, ret.c_str(), ret.size());
+    pushstring(L, ret);
     return 1;
 }
 

--- a/src/apis/http.cpp
+++ b/src/apis/http.cpp
@@ -76,7 +76,7 @@ struct http_check_t {
 static std::string http_success(lua_State *L, void* data) {
     http_handle_t * handle = (http_handle_t*)data;
     luaL_checkstack(L, 30, "Unable to allocate HTTP handle");
-    lua_pushlstring(L, handle->url.c_str(), handle->url.size());
+    pushstring(L, handle->url);
 
     *(http_handle_t**)lua_newuserdata(L, sizeof(http_handle_t*)) = handle;
     lua_createtable(L, 0, 1);
@@ -139,7 +139,7 @@ static std::string http_success(lua_State *L, void* data) {
 static std::string http_failure(lua_State *L, void* data) {
     http_handle_t * handle = (http_handle_t*)data;
     luaL_checkstack(L, 30, "Unable to allocate HTTP handle");
-    lua_pushlstring(L, handle->url.c_str(), handle->url.size());
+    pushstring(L, handle->url);
     if (!handle->failureReason.empty()) lua_pushstring(L, handle->failureReason.c_str());
     if (handle->stream != NULL) {
         *(http_handle_t**)lua_newuserdata(L, sizeof(http_handle_t*)) = handle;
@@ -205,7 +205,7 @@ static std::string http_failure(lua_State *L, void* data) {
 
 static std::string http_check(lua_State *L, void* data) {
     http_check_t * res = (http_check_t*)data;
-    lua_pushlstring(L, res->url.c_str(), res->url.size());
+    pushstring(L, res->url);
     lua_pushboolean(L, res->status.empty());
     if (res->status.empty()) lua_pushnil(L);
     else lua_pushstring(L, res->status.c_str());
@@ -958,7 +958,7 @@ static std::string websocket_message(lua_State *L, void* userp) {
     ws_message * message = (ws_message*)userp;
     if (message->url.empty()) lua_pushinteger(L, message->port);
     else lua_pushstring(L, message->url.c_str());
-    lua_pushlstring(L, message->data.c_str(), message->data.size());
+    pushstring(L, message->data);
     lua_pushboolean(L, message->binary);
     if (message->clientID) lua_pushlightuserdata(L, message->clientID);
     delete message;

--- a/src/apis/http_emscripten.cpp
+++ b/src/apis/http_emscripten.cpp
@@ -256,7 +256,7 @@ int http_request(lua_State *L) {
 
 std::string http_check(lua_State *L, void* data) {
     http_check_t * res = (http_check_t*)data;
-    lua_pushlstring(L, res->url.c_str(), res->url.size());
+    pushstring(L, res->url);
     lua_pushboolean(L, res->status.empty());
     if (res->status.empty()) lua_pushnil(L);
     else lua_pushstring(L, res->status.c_str());

--- a/src/apis/mounter.cpp
+++ b/src/apis/mounter.cpp
@@ -32,7 +32,7 @@ static int mounter_mount(lua_State *L) {
     if (config.mount_mode == MOUNT_MODE_NONE) luaL_error(L, "Mounting is disabled");
     bool read_only = config.mount_mode != MOUNT_MODE_RW;
     if (lua_isboolean(L, 3) && config.mount_mode != MOUNT_MODE_RO_STRICT) read_only = lua_toboolean(L, 3);
-    lua_pushboolean(L, addMount(get_comp(L), wstr(luaL_checkstring(L, 2)), luaL_checkstring(L, 1), read_only));
+    lua_pushboolean(L, addMount(get_comp(L), luaL_checkstring(L, 2), luaL_checkstring(L, 1), read_only));
     return 1;
 }
 
@@ -41,7 +41,7 @@ static int mounter_unmount(lua_State *L) {
     if (config.mount_mode == MOUNT_MODE_NONE) luaL_error(L, "Mounting is disabled");
     Computer * computer = get_comp(L);
     const char * comp_path = luaL_checkstring(L, 1);
-    std::vector<std::string> elems = split(comp_path, "/\\");
+    std::vector<std::string> elems = split(std::string(comp_path), "/\\");
     std::list<std::string> pathc;
     for (const std::string& s : elems) {
         if (s == "..") { 
@@ -80,8 +80,8 @@ static int mounter_list(lua_State *L) {
             lua_createtable(L, 1, 0); // table, entries
         }
         lua_pushinteger(L, lua_objlen(L, -1) + 1); // table, entries, index
-        if (std::regex_match(std::get<1>(m), pathregex(WS("\\d+:")))) lua_pushfstring(L, "(virtual mount:%s)", std::get<1>(m).substr(0, std::get<1>(m).size()-1).c_str());
-        else lua_pushstring(L, astr(std::get<1>(m)).c_str()); // table, entries, index, value
+        if (std::regex_match(std::get<1>(m), std::basic_regex<path_t::value_type>("\\d+:"))) lua_pushfstring(L, "(virtual mount:%s)", std::get<1>(m).substr(0, std::get<1>(m).size()-1).c_str());
+        else lua_pushstring(L, path_t(std::get<1>(m)).string().c_str()); // table, entries, index, value
         lua_settable(L, -3); // table, entries
         lua_pushstring(L, ss.str().c_str()); // table, entries, key
         lua_pushvalue(L, -2); // table, entries, key, entries
@@ -95,7 +95,7 @@ static int mounter_isReadOnly(lua_State *L) {
     lastCFunction = __func__;
     Computer * computer = get_comp(L);
     const char * comp_path = luaL_checkstring(L, 1);
-    std::vector<std::string> elems = split(comp_path, "/\\");
+    std::vector<std::string> elems = split(std::string(comp_path), "/\\");
     std::list<std::string> pathc;
     for (const std::string& s : elems) {
         if (s == "..") {

--- a/src/apis/mounter.cpp
+++ b/src/apis/mounter.cpp
@@ -80,7 +80,7 @@ static int mounter_list(lua_State *L) {
             lua_createtable(L, 1, 0); // table, entries
         }
         lua_pushinteger(L, lua_objlen(L, -1) + 1); // table, entries, index
-        if (std::regex_match(std::get<1>(m), std::basic_regex<path_t::value_type>("\\d+:"))) lua_pushfstring(L, "(virtual mount:%s)", std::get<1>(m).substr(0, std::get<1>(m).size()-1).c_str());
+        if (std::regex_match(std::get<1>(m), std::basic_regex<path_t::value_type>(path_t("\\d+:").native()))) lua_pushfstring(L, "(virtual mount:%s)", std::get<1>(m).substr(0, std::get<1>(m).size()-1).c_str());
         else lua_pushstring(L, path_t(std::get<1>(m)).string().c_str()); // table, entries, index, value
         lua_settable(L, -3); // table, entries
         lua_pushstring(L, ss.str().c_str()); // table, entries, key

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -29,7 +29,7 @@ extern "C" {extern void syncfs(); }
 
 struct computer_configuration getComputerConfig(int id) {
     struct computer_configuration cfg = {"", true, false, false, 0, 0};
-    std::ifstream in(getBasePath() + WS("/config/") + to_path_t(id) + WS(".json"));
+    std::ifstream in(getBasePath() / "config" / (std::to_string(id) + ".json"));
     if (!in.is_open()) return cfg;
     if (in.peek() == std::ifstream::traits_type::eof()) { in.close(); return cfg; } // treat an empty file as if it didn't exist in the first place
     Value root;
@@ -85,7 +85,7 @@ void setComputerConfig(int id, const computer_configuration& cfg) {
     root["startFullscreen"] = cfg.startFullscreen;
     root["computerWidth"] = cfg.computerWidth;
     root["computerHeight"] = cfg.computerHeight;
-    std::ofstream out(getBasePath() + WS("/config/") + to_path_t(id) + WS(".json"));
+    std::ofstream out(getBasePath() / "config" / (std::to_string(id) + ".json"));
     out << root;
     out.close();
 #ifdef __EMSCRIPTEN__
@@ -156,7 +156,7 @@ const std::string hiddenOptions[] = {"customFontPath", "customFontScale", "custo
 std::unordered_map<std::string, Poco::Dynamic::Var> unknownOptions;
 
 void config_init() {
-    createDirectory(getBasePath() + WS("/config"));
+    fs::create_directories(getBasePath() / "config");
     config = {
         true,
         true,
@@ -231,7 +231,7 @@ void config_init() {
         false,
         false
     };
-    std::ifstream in(getBasePath() + WS("/config/global.json"));
+    std::ifstream in(getBasePath() / "config" / "global.json");
     if (!in.is_open()) { onboardingMode = 1; return; }
     Value root;
     Poco::JSON::Object::Ptr p;
@@ -420,7 +420,7 @@ void config_save() {
     for (const auto& e : config.pluginData) pluginRoot[e.first] = e.second;
     root["pluginData"] = pluginRoot;
     for (const auto& opt : unknownOptions) root[opt.first] = opt.second;
-    std::ofstream out(getBasePath() + WS("/config/global.json"));
+    std::ofstream out(getBasePath() / "config"/"global.json");
     out << root;
     out.close();
 #ifdef __EMSCRIPTEN__

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -27,6 +27,13 @@ int onboardingMode = 0;
 extern "C" {extern void syncfs(); }
 #endif
 
+static void showMessage(const std::string& message) {
+    if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
+    else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
+    else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
+    else fprintf(stderr, "%s\n", message.c_str());
+}
+
 struct computer_configuration getComputerConfig(int id) {
     struct computer_configuration cfg = {"", true, false, false, 0, 0};
     std::ifstream in(getBasePath() / "config" / (std::to_string(id) + ".json"));
@@ -36,29 +43,17 @@ struct computer_configuration getComputerConfig(int id) {
     Poco::JSON::Object::Ptr p;
     try { p = root.parse(in); } catch (Poco::JSON::JSONException &e) {
         cfg.loadFailure = true;
-        const std::string message = "An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": " + e.message() + ". The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": " + e.message() + ". The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return cfg;
     } catch (std::exception &e) {
         cfg.loadFailure = true;
-        const std::string message = "An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": " + e.what() + ". The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": " + e.what() + ". The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return cfg;
     } catch (...) {
         cfg.loadFailure = true;
-        const std::string message = "An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": unknown. The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the per-computer configuration file for computer " + std::to_string(id) + ": unknown. The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return cfg;
     }
@@ -156,7 +151,8 @@ const std::string hiddenOptions[] = {"customFontPath", "customFontScale", "custo
 std::unordered_map<std::string, Poco::Dynamic::Var> unknownOptions;
 
 void config_init() {
-    fs::create_directories(getBasePath() / "config");
+    std::error_code e;
+    fs::create_directories(getBasePath() / "config", e);
     config = {
         true,
         true,
@@ -231,6 +227,11 @@ void config_init() {
         false,
         false
     };
+    if (e) {
+        configLoadError = true;
+        showMessage("An error occurred while parsing the global configuration file: Could not create config directory: " + std::string(e.message()) + ". The current session's config will be reset to default, and any changes made will not be saved.");
+        return;
+    }
     std::ifstream in(getBasePath() / "config" / "global.json");
     if (!in.is_open()) { onboardingMode = 1; return; }
     Value root;
@@ -239,29 +240,17 @@ void config_init() {
         p = root.parse(in);
     } catch (Poco::JSON::JSONException &e) {
         configLoadError = true;
-        const std::string message = "An error occurred while parsing the global configuration file: " + e.message() + ". The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the global configuration file: " + e.message() + ". The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return;
     } catch (std::exception &e) {
         configLoadError = true;
-        const std::string message = "An error occurred while parsing the global configuration file: " + std::string(e.what()) + ". The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the global configuration file: " + std::string(e.what()) + ". The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return;
     } catch (...) {
         configLoadError = true;
-        const std::string message = "An error occurred while parsing the global configuration file: unknown. The current session's config will be reset to default, and any changes made will not be saved.";
-        if (selectedRenderer == 0 || selectedRenderer == 5) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str(), NULL);
-        else if (selectedRenderer == 3) RawTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else if (selectedRenderer == 4) TRoRTerminal::showGlobalMessage(SDL_MESSAGEBOX_WARNING, "Error parsing JSON", message.c_str());
-        else fprintf(stderr, "%s\n", message.c_str());
+        showMessage("An error occurred while parsing the global configuration file: unknown. The current session's config will be reset to default, and any changes made will not be saved.");
         in.close();
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -640,6 +640,7 @@ int parseArguments(const std::vector<std::string>& argv) {
                       << "  --headless                       Outputs only text straight to stdout\n"
                       << "  --raw                            Outputs terminal contents using a binary format\n"
                       << "  --raw-client                     Renders raw output from another terminal (GUI only)\n"
+                      << "  --raw-websocket <url>            Like --raw-client, but connects to a WebSocket server\n"
                       << "  --tror                           Outputs TRoR (terminal redirect over Rednet) packets\n"
                       << "  --hardware                       Outputs to a GUI terminal with hardware acceleration\n"
                       << "  --single                         Forces all screen output to a single window\n\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,10 @@ using namespace Poco::Net;
 extern "C" {extern int Android_JNI_SetupThread(void);}
 #endif
 
+#ifdef _WIN32
+extern void uploadCrashDumps();
+#endif
+
 extern void awaitTasks(const std::function<bool()>& predicate = []()->bool{return true;});
 extern void http_server_stop();
 extern void clearPeripherals();
@@ -506,8 +510,6 @@ static void migrateData(bool forced) {
 static int id = 0;
 static bool manualID = false;
 static bool forceMigrate = false;
-static std::string base_path_storage;
-static std::string rom_path_storage;
 static path_t customDataDir;
 
 int parseArguments(const std::vector<std::string>& argv) {
@@ -528,15 +530,15 @@ int parseArguments(const std::vector<std::string>& argv) {
         else if (arg == "--exec") script_file = "\x1b" + argv[++i];
         else if (arg == "--args") script_args = argv[++i];
         else if (arg == "--plugin") customPlugins.push_back(argv[++i]);
-        else if (arg == "--directory" || arg == "-d" || arg == "--data-dir") setBasePath(argv[++i].c_str());
-        else if (arg.substr(0, 3) == "-d=") setBasePath((base_path_storage = arg.substr(3)).c_str());
+        else if (arg == "--directory" || arg == "-d" || arg == "--data-dir") setBasePath(argv[++i]);
+        else if (arg.substr(0, 3) == "-d=") setBasePath(arg.substr(3));
         else if (arg == "--computers-dir" || arg == "-C") computerDir = argv[++i];
         else if (arg.substr(0, 3) == "-C=") computerDir = arg.substr(3);
         else if (arg == "--start-dir") customDataDir = argv[++i];
         else if (arg.substr(0, 3) == "-c=") customDataDir = arg.substr(3);
         else if (arg == "--rom") setROMPath(argv[++i].c_str());
-        else if (arg == "--assets-dir" || arg == "-a") setROMPath((rom_path_storage = path_t(argv[++i])/"assets"/"computercraft"/"lua").c_str());
-        else if (arg.substr(0, 3) == "-a=") setROMPath((rom_path_storage = path_t(arg.substr(3))/"assets"/"computercraft"/"lua").c_str());
+        else if (arg == "--assets-dir" || arg == "-a") setROMPath(path_t(argv[++i])/"assets"/"computercraft"/"lua");
+        else if (arg.substr(0, 3) == "-a=") setROMPath(path_t(arg.substr(3))/"assets"/"computercraft"/"lua");
         else if (arg == "--mc-save") computerDir = getMCSavePath() / argv[++i] / "computer";
         else if (arg == "-i" || arg == "--id") { manualID = true; id = std::stoi(argv[++i]); }
         else if (arg == "--migrate") forceMigrate = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,12 +73,12 @@ std::unordered_map<unsigned, uint8_t> rawClientTerminalIDs;
 std::string script_file;
 std::string script_args;
 std::string updateAtQuit;
-Poco::JSON::Object updateAtQuitRoot;
 int returnValue = 0;
 std::unordered_map<path_t, std::string> globalPluginErrors;
 static std::string rawWebSocketURL;
 
 #if !defined(__EMSCRIPTEN__) && !CRAFTOSPC_INDEV
+Poco::JSON::Object updateAtQuitRoot;
 static void* releaseNotesThread(void* data) {
     Computer * comp = (Computer*)data;
 #ifdef __APPLE__
@@ -94,9 +94,9 @@ static void* releaseNotesThread(void* data) {
         freedComputers.erase(comp);
     try {
 #ifdef STANDALONE_ROM
-        runComputer(comp, wstr(standaloneDebug["bios.lua"].data));
+        runComputer(comp, "debug/bios.lua", standaloneDebug["bios.lua"].data);
 #else
-        runComputer(comp, WS("debug/bios.lua"));
+        runComputer(comp, "debug/bios.lua");
 #endif
     } catch (std::exception &e) {
         fprintf(stderr, "Uncaught exception while executing computer %d (last C function: %s): %s\n", comp->id, lastCFunction, e.what());
@@ -429,8 +429,7 @@ static int runRenderer(const std::function<std::string()>& read, const std::func
 
 static void migrateData(bool forced) {
     migrateOldData();
-    struct_stat st;
-    if ((forced || platform_stat(getBasePath().c_str(), &st) != 0) && platform_stat((getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux")).c_str(), &st) == 0) {
+    if ((forced || !fs::exists(getBasePath())) && fs::exists(getBasePath().parent_path() / "ccemux")) {
         if (!forced) {
             SDL_MessageBoxData data;
             data.title = "Migrate Data";
@@ -449,11 +448,12 @@ static void migrateData(bool forced) {
             if (!retval) return;
         }
         // Copy computer data
-        std::list<path_t> failures;
-        const auto retval = recursiveCopy(getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux") PATH_SEP WS("computer"), getBasePath() + PATH_SEP "computer", &failures);
-        if (retval.first != 0) failures.push_back(retval.first == 1 ? getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux") PATH_SEP WS("computer") : getBasePath() + PATH_SEP "computer");
+        std::error_code copy_error;
+        std::string msg;
+        fs::copy(getBasePath().parent_path() / "ccemux" / "computer", getBasePath() / "computer", fs::copy_options::recursive | fs::copy_options::update_existing, copy_error);
+        if (copy_error) msg += "Could not copy files: " + copy_error.message() + "\n";
         // Copy config file
-        std::ifstream in(getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux") PATH_SEP WS("ccemux.json"));
+        std::ifstream in(getBasePath().parent_path() / "ccemux" / "ccemux.json");
         if (in.is_open()) {
             Value oldroot;
             Poco::JSON::Object::Ptr p;
@@ -487,12 +487,11 @@ static void migrateData(bool forced) {
                 config_save();
             } catch (Poco::JSON::JSONException &e) {
                 fprintf(stderr, "Could not read CCEmuX config file: %s\n", e.displayText().c_str());
-                failures.push_back(getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux") PATH_SEP WS("ccemux.json"));
+                msg += "Could not parse " + (getBasePath().parent_path() / "ccemux" / "ccemux.json").string() + "\n";
             }
-        } else failures.push_back(getBasePath() + PATH_SEP WS("..") PATH_SEP WS("ccemux") PATH_SEP WS("ccemux.json"));
-        if (!failures.empty()) {
-            fprintf(stderr, "Failed to copy the following files while migrating CCEmuX data:\n");
-            for (const path_t& p : failures) fprintf(stderr, "%s\n", astr(p).c_str());
+        } else msg += "Could not find " + (getBasePath().parent_path() / "ccemux" / "ccemux.json").string() + "\n";
+        if (!msg.empty()) {
+            fprintf(stderr, "Some errors occurred while copying CCEmuX data:\n%s", msg);
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Migration Failure", "Some files failed to be copied while migrating from CCEmuX. Check the console to see what failed.\n", NULL);
         } else if (forced) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Migration Success", "The migration of CCEmuX data to CraftOS-PC has completed successfully.", NULL);
     }
@@ -528,23 +527,17 @@ int parseArguments(const std::vector<std::string>& argv) {
         else if (arg.substr(0, 9) == "--script=") script_file = arg.substr(9);
         else if (arg == "--exec") script_file = "\x1b" + argv[++i];
         else if (arg == "--args") script_args = argv[++i];
-        else if (arg == "--plugin") customPlugins.push_back(wstr(argv[++i]));
+        else if (arg == "--plugin") customPlugins.push_back(argv[++i]);
         else if (arg == "--directory" || arg == "-d" || arg == "--data-dir") setBasePath(argv[++i].c_str());
         else if (arg.substr(0, 3) == "-d=") setBasePath((base_path_storage = arg.substr(3)).c_str());
-        else if (arg == "--computers-dir" || arg == "-C") computerDir = wstr(argv[++i]);
-        else if (arg.substr(0, 3) == "-C=") computerDir = wstr(arg.substr(3));
-        else if (arg == "--start-dir") customDataDir = wstr(argv[++i]);
-        else if (arg.substr(0, 3) == "-c=") customDataDir = wstr(arg.substr(3));
+        else if (arg == "--computers-dir" || arg == "-C") computerDir = argv[++i];
+        else if (arg.substr(0, 3) == "-C=") computerDir = arg.substr(3);
+        else if (arg == "--start-dir") customDataDir = argv[++i];
+        else if (arg.substr(0, 3) == "-c=") customDataDir = arg.substr(3);
         else if (arg == "--rom") setROMPath(argv[++i].c_str());
-#ifdef _WIN32
-        else if (arg == "--assets-dir" || arg == "-a") setROMPath((rom_path_storage = argv[++i] + "\\assets\\computercraft\\lua").c_str());
-        else if (arg.substr(0, 3) == "-a=") setROMPath((rom_path_storage = arg.substr(3) + "\\assets\\computercraft\\lua").c_str());
-        else if (arg == "--mc-save") computerDir = getMCSavePath() + wstr(argv[++i]) + WS("\\computer");
-#else
-        else if (arg == "--assets-dir" || arg == "-a") setROMPath((rom_path_storage = argv[++i] + "/assets/computercraft/lua").c_str());
-        else if (arg.substr(0, 3) == "-a=") setROMPath((rom_path_storage = arg.substr(3) + "/assets/computercraft/lua").c_str());
-        else if (arg == "--mc-save") computerDir = getMCSavePath() + argv[++i] + "/computer";
-#endif
+        else if (arg == "--assets-dir" || arg == "-a") setROMPath((rom_path_storage = path_t(argv[++i])/"assets"/"computercraft"/"lua").c_str());
+        else if (arg.substr(0, 3) == "-a=") setROMPath((rom_path_storage = path_t(arg.substr(3))/"assets"/"computercraft"/"lua").c_str());
+        else if (arg == "--mc-save") computerDir = getMCSavePath() / argv[++i] / "computer";
         else if (arg == "-i" || arg == "--id") { manualID = true; id = std::stoi(argv[++i]); }
         else if (arg == "--migrate") forceMigrate = true;
         else if (arg == "--mount" || arg == "--mount-ro" || arg == "--mount-rw") {
@@ -663,7 +656,6 @@ int parseArguments(const std::vector<std::string>& argv) {
 
 int main(int argc, char*argv[]) {
     lualib_debug_ccpc_functions(setcompmask_, db_debug, db_breakpoint, db_unsetbreakpoint);
-    lualib_io_ccpc_functions(mounter_fopen_, mounter_fclose_);
 #ifdef __EMSCRIPTEN__
     while (EM_ASM_INT(return window.waitingForFilesystemSynchronization ? 1 : 0;)) emscripten_sleep(100);
 #endif
@@ -677,11 +669,7 @@ int main(int argc, char*argv[]) {
         selectedRenderer = 0;
     }
 #endif
-#ifdef _WIN32
-    if (computerDir.empty()) computerDir = getBasePath() + WS("\\computer");
-#else
-    if (computerDir.empty()) computerDir = getBasePath() + WS("/computer");
-#endif
+    if (computerDir.empty()) computerDir = getBasePath() / "computer";
     if (!customDataDir.empty()) customDataDirs[id] = customDataDir;
     mainThreadID = std::this_thread::get_id();
     setupCrashHandler();
@@ -862,10 +850,12 @@ int main(int argc, char*argv[]) {
     driveQuit();
     http_server_stop();
     config_save();
+#if !defined(__EMSCRIPTEN__) && !CRAFTOSPC_INDEV
     if (!updateAtQuit.empty()) {
         updateNow(updateAtQuit, &updateAtQuitRoot);
         awaitTasks();
     }
+#endif
     if (factory) factory->quit();
     else SDL_Quit();
     // Clear out a few lists that plugins may insert functions into

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,7 +495,7 @@ static void migrateData(bool forced) {
             }
         } else msg += "Could not find " + (getBasePath().parent_path() / "ccemux" / "ccemux.json").string() + "\n";
         if (!msg.empty()) {
-            fprintf(stderr, "Some errors occurred while copying CCEmuX data:\n%s", msg);
+            fprintf(stderr, "Some errors occurred while copying CCEmuX data:\n%s", msg.c_str());
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Migration Failure", "Some files failed to be copied while migrating from CCEmuX. Check the console to see what failed.\n", NULL);
         } else if (forced) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Migration Success", "The migration of CCEmuX data to CraftOS-PC has completed successfully.", NULL);
     }

--- a/src/peripheral/debugger.cpp
+++ b/src/peripheral/debugger.cpp
@@ -41,9 +41,9 @@ static void debuggerThread(Computer * comp, void * dbgv, std::string side) {
     // in case the allocator decides to reuse pointers
     if (freedComputers.find(comp) != freedComputers.end()) freedComputers.erase(comp);
 #ifdef STANDALONE_ROM
-    runComputer(comp, wstr(standaloneDebug["bios.lua"].data));
+    runComputer(comp, "debug/bios.lua", standaloneDebug["bios.lua"].data);
 #else
-    runComputer(comp, WS("debug/bios.lua"));
+    runComputer(comp, path_t("debug")/"bios.lua");
 #endif
     freedComputers.insert(comp);
     {
@@ -185,7 +185,7 @@ static int debugger_lib_setBreakpoint(lua_State *L) {
     lua_getfield(L, LUA_REGISTRYINDEX, "_debugger");
     debugger * dbg = (debugger*)lua_touserdata(L, -1);
     const int id = !dbg->computer->breakpoints.empty() ? dbg->computer->breakpoints.rbegin()->first + 1 : 1;
-    dbg->computer->breakpoints[id] = std::make_pair("@/" + astr(fixpath(dbg->computer, lua_tostring(L, 1), false, false)), lua_tointeger(L, 2));
+    dbg->computer->breakpoints[id] = std::make_pair("@/" + fixpath(dbg->computer, lua_tostring(L, 1), false, false).string(), lua_tointeger(L, 2));
     dbg->computer->hasBreakpoints = true;
     lua_pushinteger(L, id);
     return 1;
@@ -657,8 +657,8 @@ static int debugger_lib_setStartupCode(lua_State *L) {
 
 static int debugger_lib_getPath(lua_State *L) {
     lastCFunction = __func__;
-    std::string path = astr(fixpath(get_comp(L), checkstring(L, 1), true));
-    lua_pushlstring(L, path.c_str(), path.size());
+    std::string path = fixpath(get_comp(L), checkstring(L, 1), true).string();
+    pushstring(L, path);
     return 1;
 }
 
@@ -666,11 +666,11 @@ static int debugger_lib_getInternalPath(lua_State *L) {
     lastCFunction = __func__;
     lua_getfield(L, LUA_REGISTRYINDEX, "_debugger");
     debugger * dbg = (debugger*)lua_touserdata(L, -1);
-    path_t path = wstr(checkstring(L, 1));
+    path_t::string_type path = path_t(checkstring(L, 1)).native();
     std::tuple<std::list<std::string>, path_t, bool> maxPath = std::make_tuple(std::list<std::string>(), dbg->computer->dataDir, false);
     for (const auto& mount : dbg->computer->mounts) {
-        const path_t& p = std::get<1>(mount);
-        if (path.substr(0, p.size()) == p && p.size() > std::get<1>(maxPath).size()) maxPath = mount;
+        path_t::string_type p = path_t(std::get<1>(mount)).native();
+        if (path.substr(0, p.size()) == p && p.size() > std::get<1>(maxPath).native().size()) maxPath = mount;
     }
     if (std::get<1>(maxPath).empty()) lua_pushnil(L);
     else {
@@ -678,16 +678,16 @@ static int debugger_lib_getInternalPath(lua_State *L) {
         for (const std::string& p : std::get<0>(maxPath)) {
             if (begin) {
                 begin = false;
-                lua_pushlstring(L, p.c_str(), p.size());
+                pushstring(L, p);
             } else {
                 lua_pushliteral(L, "/");
-                lua_pushlstring(L, p.c_str(), p.size());
+                pushstring(L, p);
                 lua_concat(L, 3);
             }
         }
-        std::string rest = astr(path.substr(std::get<1>(maxPath).size()));
+        std::string rest = path_t(path.substr(std::get<1>(maxPath).native().size())).string();
         for (int i = 0; i < rest.size(); i++) if (rest[i] == '\\') rest[i] = '/';
-        lua_pushlstring(L, rest.c_str(), rest.size());
+        pushstring(L, rest);
         if (!begin) lua_concat(L, 2);
     }
     return 1;
@@ -747,7 +747,7 @@ int debugger::setBreakpoint(lua_State *L) {
     lastCFunction = __func__;
     Computer * computer = get_comp(L);
     const int id = !computer->breakpoints.empty() ? computer->breakpoints.rbegin()->first + 1 : 1;
-    computer->breakpoints[id] = std::make_pair("@/" + astr(fixpath(computer, luaL_checkstring(L, 1), false, false)), luaL_checkinteger(L, 2));
+    computer->breakpoints[id] = std::make_pair("@/" + fixpath(computer, luaL_checkstring(L, 1), false, false).string(), luaL_checkinteger(L, 2));
     computer->hasBreakpoints = true;
     lua_pushinteger(L, id);
     return 1;

--- a/src/peripheral/drive.cpp
+++ b/src/peripheral/drive.cpp
@@ -137,8 +137,14 @@ int drive::insertDisk(lua_State *L, bool init) {
         comp->usedDriveMounts.insert(i);
         mount_path = "disk" + (i == 0 ? "" : std::to_string(i + 1));
         comp->mounter_initializing = true;
-        fs::create_directories(computerDir / "disk" / std::to_string(id));
-        addMount(comp, computerDir / "disk" / std::to_string(id), mount_path.c_str(), false);
+        std::error_code e;
+        fs::create_directories(computerDir / "disk" / std::to_string(id), e);
+        if (e || !addMount(comp, computerDir / "disk" / std::to_string(id), mount_path.c_str(), false)) {
+            diskType = disk_type::DISK_TYPE_NONE;
+            comp->mounter_initializing = false;
+            error = "Could not mount";
+            goto throwError;
+        }
         comp->mounter_initializing = false;
     } else if (lua_isstring(L, arg)) {
         std::string str = lua_tostring(L, arg);

--- a/src/peripheral/drive.cpp
+++ b/src/peripheral/drive.cpp
@@ -25,7 +25,7 @@ int drive::getDiskLabel(lua_State *L) {
     lastCFunction = __func__;
     if (diskType == disk_type::DISK_TYPE_AUDIO) return getAudioTitle(L);
     else if (diskType == disk_type::DISK_TYPE_MOUNT) {
-        lua_pushstring(L, astr(path.substr((path.find_last_of('\\') == std::string::npos ? path.find_last_of('/') : path.find_last_of('\\')) + 1)).c_str());
+        lua_pushstring(L, path.filename().string().c_str());
         return 1;
     }
     return 0;
@@ -63,9 +63,7 @@ int drive::getAudioTitle(lua_State *L) {
         else lua_pushnil(L);
         return 1;
     }
-    const int lastdot = (int)path.find_last_of('.');
-    const int start = path.find('\\') != std::string::npos ? (int)path.find_last_of('\\') + 1 : (int)path.find_last_of('/') + 1;
-    lua_pushstring(L, astr(path.substr(start, lastdot > start ? lastdot - start : UINT32_MAX)).c_str());
+    lua_pushstring(L, path.stem().string().c_str());
     return 1;
 }
 
@@ -74,7 +72,7 @@ int drive::playAudio(lua_State *L) {
 #ifndef NO_MIXER
     if (diskType != disk_type::DISK_TYPE_AUDIO) return 0;
     if (music != NULL) stopAudio(L);
-    music = Mix_LoadMUS(astr(path).c_str());
+    music = Mix_LoadMUS(path.string().c_str());
     if (music == NULL) fprintf(stderr, "Could not load audio: %s\n", Mix_GetError());
     if (Mix_PlayMusic(music, 1) == -1) fprintf(stderr, "Could not play audio: %s\n", Mix_GetError());
 #endif
@@ -139,35 +137,20 @@ int drive::insertDisk(lua_State *L, bool init) {
         comp->usedDriveMounts.insert(i);
         mount_path = "disk" + (i == 0 ? "" : std::to_string(i + 1));
         comp->mounter_initializing = true;
-#ifdef _WIN32
-        createDirectory(computerDir + WS("\\disk\\") + to_path_t(id));
-        addMount(comp, computerDir + WS("\\disk\\") + to_path_t(id), mount_path.c_str(), false);
-#else
-        createDirectory((computerDir + "/disk/" + std::to_string(id)).c_str());
-        addMount(comp, (computerDir + "/disk/" + std::to_string(id)).c_str(), mount_path.c_str(), false);
-#endif
+        fs::create_directories(computerDir / "disk" / std::to_string(id));
+        addMount(comp, computerDir / "disk" / std::to_string(id), mount_path.c_str(), false);
         comp->mounter_initializing = false;
     } else if (lua_isstring(L, arg)) {
-        path = wstr(lua_tostring(L, arg));
-        struct_stat st;
+        std::string str = lua_tostring(L, arg);
 #ifndef STANDALONE_ROM
-        if (path.substr(0, 9) == WS("treasure:")) {
-#ifdef _WIN32
-            for (size_t i = 9; i < path.size(); i++) if (path[i] == '/') path[i] = '\\';
-            path = getROMPath() + WS("\\treasure\\") + path.substr(9);
-#else
-            path = getROMPath() + WS("/treasure/") + path.substr(9);
-#endif
-        } else if (path.substr(0, 7) == WS("record:")) {
-#ifdef _WIN32
-            path = getROMPath() + WS("\\sounds\\minecraft\\sounds\\records\\") + path.substr(7) + WS(".ogg");
-#else
-            path = getROMPath() + WS("/sounds/minecraft/sounds/records/") + path.substr(7) + WS(".ogg");
-#endif
+        if (str.substr(0, 9) == "treasure:") {
+            path = getROMPath() / "treasure" / str.substr(9);
+        } else if (str.substr(0, 7) == "record:") {
+            path = getROMPath() / "sounds"/"minecraft"/"sounds"/"records" / (str.substr(7) + ".ogg");
         } else
 #endif
-        if (path.substr(0, 9) == WS("computer:")) {
-            try {std::stoi(path.substr(9));}
+        if (str.substr(0, 9) == "computer:") {
+            try {std::stoi(str.substr(9));}
             catch (std::invalid_argument &e) {
                 if (init) throw std::invalid_argument("Could not mount: Invalid computer ID");
                 else {
@@ -175,11 +158,7 @@ int drive::insertDisk(lua_State *L, bool init) {
                     goto throwError;
                 }
             }
-#ifdef _WIN32
-            path = getBasePath() + WS("\\computer\\") + path.substr(9);
-#else
-            path = getBasePath() + WS("/computer/") + path.substr(9);
-#endif
+            path = getBasePath() / "computer" / str.substr(9);
         }
 #ifdef NO_MOUNTER
         else {
@@ -189,8 +168,10 @@ int drive::insertDisk(lua_State *L, bool init) {
                 goto throwError;
             }
         }
+#else
+        else path = str;
 #endif
-        if (platform_stat(path.c_str(), &st) != 0) {
+        if (!fs::exists(path)) {
             if (init) throw std::system_error(errno, std::system_category(), "Could not mount: ");
             else {
                 error = "Could not mount: %s";
@@ -198,7 +179,7 @@ int drive::insertDisk(lua_State *L, bool init) {
                 goto throwErrorParam;
             }
         }
-        if (S_ISDIR(st.st_mode)) {
+        if (fs::is_directory(path)) {
             diskType = disk_type::DISK_TYPE_MOUNT;
             int i;
             for (i = 0; comp->usedDriveMounts.find(i) != comp->usedDriveMounts.end(); i++) {}

--- a/src/peripheral/printer.cpp
+++ b/src/peripheral/printer.cpp
@@ -152,7 +152,7 @@ printer::printer(lua_State *L, const char * side) {
         throw;
     }
 #else
-    createDirectory(outPath.c_str());
+    fs::create_directories(outPath);
 #endif
 }
 

--- a/src/peripheral/printer.cpp
+++ b/src/peripheral/printer.cpp
@@ -152,7 +152,7 @@ printer::printer(lua_State *L, const char * side) {
         throw;
     }
 #else
-    fs::create_directories(outPath);
+    fs::create_directories(outPath); // throw
 #endif
 }
 

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -21,18 +21,14 @@
 
 using path_t = std::filesystem::path;
 
-#ifdef _WIN32
-#define access _waccess
-#endif
-
 #ifdef __IPHONEOS__
 extern void iOS_SetWindowTitle(SDL_Window * win, const char * title);
 #define SDL_SetWindowTitle iOS_SetWindowTitle
 #endif
 
 extern void setThreadName(std::thread &t, const std::string& name);
-extern void setBasePath(const char * path);
-extern void setROMPath(const char * path);
+extern void setBasePath(path_t path);
+extern void setROMPath(path_t path);
 extern path_t getBasePath();
 extern path_t getROMPath();
 extern path_t getPlugInPath();

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -11,6 +11,7 @@
 
 #ifndef PLATFORM_HPP
 #define PLATFORM_HPP
+#include <filesystem>
 #include <string>
 #include <thread>
 #include <lib.hpp>
@@ -18,50 +19,10 @@
 #include <Poco/JSON/Object.h>
 #include <Poco/Net/Context.h>
 
-// Filesystem definitions (UTF-16 vs. not Windows)
-#ifdef WIN32
-#define pathstream_t std::wstringstream
-#define pathregex std::wregex
-#define platform_stat _wstat
-#define platform_access _waccess
-extern FILE* platform_fopen(const wchar_t* path, const char * mode);
-#define platform_remove _wremove
-#define platform_rename _wrename
-#define platform_opendir _wopendir
-#define platform_readdir _wreaddir
-#define platform_closedir _wclosedir
-#define platform_DIR WDIR
-#define struct_dirent struct _wdirent
-#define struct_stat struct _stat
-extern path_t wstr(std::string str);
-extern std::string astr(path_t str);
-#define to_path_t std::to_wstring
-#define WS(s) L##s
-#define pathcmp wcscmp
+using path_t = std::filesystem::path;
 
-extern char* basename(char* path);
-extern char* dirname(char* path);
-extern void uploadCrashDumps();
-#else
-//typedef std::string path_t;
-#define pathstream_t std::stringstream
-#define pathregex std::regex
-#define platform_stat stat
-#define platform_access access
-#define platform_fopen fopen
-#define platform_remove remove
-#define platform_rename rename
-#define platform_opendir opendir
-#define platform_readdir readdir
-#define platform_closedir closedir
-#define platform_DIR DIR
-#define struct_dirent struct dirent
-#define struct_stat struct stat
-#define wstr(s) (s)
-#define astr(s) (s)
-#define to_path_t std::to_string
-#define WS(s) s
-#define pathcmp strcmp
+#ifdef _WIN32
+#define access _waccess
 #endif
 
 #ifdef __IPHONEOS__
@@ -70,10 +31,6 @@ extern void iOS_SetWindowTitle(SDL_Window * win, const char * title);
 #endif
 
 extern void setThreadName(std::thread &t, const std::string& name);
-extern int createDirectory(const path_t& path);
-extern unsigned long long getFreeSpace(const path_t& path);
-extern unsigned long long getCapacity(const path_t& path);
-extern int removeDirectory(const path_t& path);
 extern void setBasePath(const char * path);
 extern void setROMPath(const char * path);
 extern path_t getBasePath();

--- a/src/platform/CraftOS-PC 2.rc
+++ b/src/platform/CraftOS-PC 2.rc
@@ -60,8 +60,8 @@ MANIFEST                RT_MANIFEST             "..\\..\\resources\\CraftOS-PC.e
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,6,6,0
- PRODUCTVERSION 2,6,6,0
+ FILEVERSION 2,7,0,0
+ PRODUCTVERSION 2,7,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -77,12 +77,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "CraftOS-PC"
-            VALUE "FileVersion", "2.6.6.0"
+            VALUE "FileVersion", "2.7.0.0"
             VALUE "InternalName", "CraftOS-PC.exe"
             VALUE "LegalCopyright", "Copyright (C) 2019-2022 JackMacWindows."
             VALUE "OriginalFilename", "CraftOS-PC.exe"
             VALUE "ProductName", "CraftOS-PC"
-            VALUE "ProductVersion", "2.6.6.0"
+            VALUE "ProductVersion", "2.7.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/platform/android.cpp
+++ b/src/platform/android.cpp
@@ -77,36 +77,9 @@ void setThreadName(std::thread &t, const std::string& name) {
     pthread_setname_np(t.native_handle(), name.c_str());
 }
 
-void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {
-    
-}
+void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {}
 
-int recursiveCopyPlatform(const std::string& fromDir, const std::string& toDir) {
-    struct stat statbuf;
-    if (!stat(fromDir.c_str(), &statbuf)) {
-        if (S_ISDIR(statbuf.st_mode)) {
-            fs::create_directories(toDir);
-            DIR *d = opendir(fromDir.c_str());
-            int r = -1;
-            if (d) {
-                struct dirent *p;
-                r = 0;
-                while (!r && (p=readdir(d))) {
-                    /* Skip the names "." and ".." as we don't want to recurse on them. */
-                    if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) continue;
-                    r = recursiveCopyPlatform(fromDir + "/" + std::string(p->d_name), toDir + "/" + std::string(p->d_name));
-                }
-                closedir(d);
-            }
-            if (!r) r = rmdir(fromDir.c_str());
-            return r;
-        } else return rename(fromDir.c_str(), toDir.c_str());
-    } else return -1;
-}
-
-void migrateOldData() {
-    
-}
+void migrateOldData() {}
 
 void copyImage(SDL_Surface* surf, SDL_Window* win) {
     fprintf(stderr, "Warning: Android does not support taking screenshots to the clipboard.\n");

--- a/src/platform/android.cpp
+++ b/src/platform/android.cpp
@@ -47,7 +47,7 @@ void setROMPath(const char * path) {
     rom_path = path;
 }
 
-std::string getBasePath() {
+path_t getBasePath() {
     if (base_path.empty()) {
         if (SDL_AndroidGetExternalStorageState() & (SDL_ANDROID_EXTERNAL_STORAGE_READ | SDL_ANDROID_EXTERNAL_STORAGE_WRITE))
             base_path = std::string(SDL_AndroidGetExternalStoragePath());
@@ -56,14 +56,14 @@ std::string getBasePath() {
     return base_path;
 }
 
-std::string getROMPath() {
+path_t getROMPath() {
     if (rom_path.empty()) {
         rom_path = std::string(SDL_AndroidGetInternalStoragePath());
         rom_path = rom_path.substr(0, rom_path.find_last_of('/') + 1) + "cache";
     }
     return rom_path;
 }
-std::string getPlugInPath() {
+path_t getPlugInPath() {
     if (rom_path.empty()) {
         rom_path = std::string(SDL_AndroidGetInternalStoragePath());
         rom_path = rom_path.substr(0, rom_path.find_last_of('/') + 1) + "cache";
@@ -71,64 +71,12 @@ std::string getPlugInPath() {
     return rom_path + "/plugins/";
 }
 
-std::string getMCSavePath() {
+path_t getMCSavePath() {
     return "";
 }
 
 void setThreadName(std::thread &t, const std::string& name) {
     pthread_setname_np(t.native_handle(), name.c_str());
-}
-
-int createDirectory(const std::string& path) {
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0 ) return !S_ISDIR(st.st_mode);
-    if (mkdir(path.c_str(), 0777) != 0) {
-        if (errno == ENOENT && path != "/" && !path.empty()) {
-            if (createDirectory(path.substr(0, path.find_last_of('/')).c_str())) return 1;
-            mkdir(path.c_str(), 0777);
-        } else if (errno != EEXIST) return 1;
-    }
-    return 0;
-}
-
-int removeDirectory(const std::string& path) {
-    struct stat statbuf;
-    if (!stat(path.c_str(), &statbuf)) {
-        if (S_ISDIR(statbuf.st_mode)) {
-            DIR *d = opendir(path.c_str());
-            int r = -1;
-            if (d) {
-                struct dirent *p;
-                r = 0;
-                while (!r && (p=readdir(d))) {
-                    /* Skip the names "." and ".." as we don't want to recurse on them. */
-                    if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) continue;
-                    r = removeDirectory(path + "/" + std::string(p->d_name));
-                }
-                closedir(d);
-            }
-            if (!r) r = rmdir(path.c_str());
-            return r;
-        } else return unlink(path.c_str());
-    } else return -1;
-}
-
-unsigned long long getFreeSpace(const std::string& path) {
-    struct statvfs st;
-    if (statvfs(path.c_str(), &st) != 0) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getFreeSpace(path.substr(0, path.find_last_of("/")-1));
-    }
-    return st.f_bavail * st.f_bsize;
-}
-
-unsigned long long getCapacity(const std::string& path) {
-    struct statvfs st;
-    if (statvfs(path.c_str(), &st) != 0) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getCapacity(path.substr(0, path.find_last_of("/")-1));
-    }
-    return st.f_blocks * st.f_frsize;
 }
 
 void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {
@@ -139,7 +87,7 @@ int recursiveCopyPlatform(const std::string& fromDir, const std::string& toDir) 
     struct stat statbuf;
     if (!stat(fromDir.c_str(), &statbuf)) {
         if (S_ISDIR(statbuf.st_mode)) {
-            createDirectory(toDir);
+            fs::create_directories(toDir);
             DIR *d = opendir(fromDir.c_str());
             int r = -1;
             if (d) {

--- a/src/platform/android.cpp
+++ b/src/platform/android.cpp
@@ -36,39 +36,37 @@ extern "C" {
 #include "../util.hpp"
 #include "../terminal/SDLTerminal.hpp"
 
-std::string base_path;
-std::string rom_path;
+path_t base_path;
+path_t rom_path;
 
-void setBasePath(const char * path) {
+void setBasePath(path_t path) {
     base_path = path;
 }
 
-void setROMPath(const char * path) {
+void setROMPath(path_t path) {
     rom_path = path;
 }
 
 path_t getBasePath() {
     if (base_path.empty()) {
         if (SDL_AndroidGetExternalStorageState() & (SDL_ANDROID_EXTERNAL_STORAGE_READ | SDL_ANDROID_EXTERNAL_STORAGE_WRITE))
-            base_path = std::string(SDL_AndroidGetExternalStoragePath());
-        else base_path = std::string(SDL_AndroidGetInternalStoragePath());
+            base_path = path_t(SDL_AndroidGetExternalStoragePath());
+        else base_path = path_t(SDL_AndroidGetInternalStoragePath());
     }
     return base_path;
 }
 
 path_t getROMPath() {
     if (rom_path.empty()) {
-        rom_path = std::string(SDL_AndroidGetInternalStoragePath());
-        rom_path = rom_path.substr(0, rom_path.find_last_of('/') + 1) + "cache";
+        rom_path = path_t(SDL_AndroidGetInternalStoragePath()).parent_path() / "cache";
     }
     return rom_path;
 }
 path_t getPlugInPath() {
     if (rom_path.empty()) {
-        rom_path = std::string(SDL_AndroidGetInternalStoragePath());
-        rom_path = rom_path.substr(0, rom_path.find_last_of('/') + 1) + "cache";
+        rom_path = path_t(SDL_AndroidGetInternalStoragePath()).parent_path() / "cache";
     }
-    return rom_path + "/plugins/";
+    return rom_path / "plugins";
 }
 
 path_t getMCSavePath() {

--- a/src/platform/darwin.cpp
+++ b/src/platform/darwin.cpp
@@ -39,7 +39,7 @@ extern "C" {
 const char * rom_path = CUSTOM_ROM_DIR;
 path_t rom_path_expanded;
 #else
-const char * rom_path = "/usr/share/craftos";
+path_t rom_path = "/usr/share/craftos";
 #endif
 #ifdef FS_ROOT
 const char * base_path = "";
@@ -48,15 +48,15 @@ const char * base_path = "$XDG_DATA_HOME/craftos-pc";
 #endif
 path_t base_path_expanded;
 
-void setBasePath(const char * path) {
-    base_path = path;
+void setBasePath(path_t path) {
     base_path_expanded = path;
 }
 
-void setROMPath(const char * path) {
-    rom_path = path;
+void setROMPath(path_t path) {
 #ifdef CUSTOM_ROM_DIR
     rom_path_expanded = path;
+#else
+    rom_path = path;
 #endif
 }
 
@@ -90,7 +90,7 @@ path_t getROMPath() {
 path_t getPlugInPath() { return getROMPath() / "plugins"; }
 #else
 path_t getROMPath() { return rom_path; }
-path_t getPlugInPath() { return path_t(rom_path) / "plugins"; }
+path_t getPlugInPath() { return rom_path / "plugins"; }
 #endif
 
 path_t getMCSavePath() {

--- a/src/platform/darwin.cpp
+++ b/src/platform/darwin.cpp
@@ -102,7 +102,9 @@ static int recursiveMove(const std::string& fromDir, const std::string& toDir) {
     struct stat statbuf;
     if (!stat(fromDir.c_str(), &statbuf)) {
         if (S_ISDIR(statbuf.st_mode)) {
-            fs::create_directories(toDir);
+            std::error_code e;
+            fs::create_directories(toDir, e);
+            if (e) return e.value();
             DIR *d = opendir(fromDir.c_str());
             int r = -1;
             if (d) {

--- a/src/platform/darwin.cpp
+++ b/src/platform/darwin.cpp
@@ -39,13 +39,9 @@ extern "C" {
 const char * rom_path = CUSTOM_ROM_DIR;
 path_t rom_path_expanded;
 #else
-path_t rom_path = "/usr/share/craftos";
+path_t rom_path = "/usr/local/share/craftos";
 #endif
-#ifdef FS_ROOT
-const char * base_path = "";
-#else
-const char * base_path = "$XDG_DATA_HOME/craftos-pc";
-#endif
+const char * base_path = "$HOME/Library/Application\\ Support/CraftOS-PC";
 path_t base_path_expanded;
 
 void setBasePath(path_t path) {
@@ -67,12 +63,6 @@ path_t getBasePath() {
     base_path_expanded = p.we_wordv[0];
     for (unsigned i = 1; i < p.we_wordc; i++) base_path_expanded += p.we_wordv[i];
     wordfree(&p);
-    if (base_path_expanded == "/craftos-pc") {
-        wordexp("$HOME/.local/share/craftos-pc", &p, 0);
-        base_path_expanded = p.we_wordv[0];
-        for (unsigned i = 1; i < p.we_wordc; i++) base_path_expanded += p.we_wordv[i];
-        wordfree(&p);
-    }
     return base_path_expanded;
 }
 

--- a/src/platform/emscripten.cpp
+++ b/src/platform/emscripten.cpp
@@ -17,9 +17,9 @@
 
 void setThreadName(std::thread &t, const std::string& name) {}
 
-void setBasePath(const char * path) {}
+void setBasePath(path_t path) {}
 
-void setROMPath(const char * path) {}
+void setROMPath(path_t path) {}
 
 path_t getBasePath() {
     return "/user-data";

--- a/src/platform/emscripten.cpp
+++ b/src/platform/emscripten.cpp
@@ -17,63 +17,23 @@
 
 void setThreadName(std::thread &t, const std::string& name) {}
 
-unsigned long long getFreeSpace(const std::string& path) {
-    return 1000000;
-}
-
-unsigned long long getCapacity(const std::string& path) {
-    return 1000000;
-}
-
-int createDirectory(const std::string& path) {
-    if (mkdir(path.c_str(), 0777) != 0) {
-        if (errno == ENOENT && path != "/" && !path.empty()) {
-            if (createDirectory(path.substr(0, path.find_last_of('/')).c_str())) return 1;
-            mkdir(path.c_str(), 0777);
-        } else if (errno != EEXIST) return 1;
-    }
-    return 0;
-}
-
-int removeDirectory(const std::string& path) {
-    struct stat statbuf;
-    if (!stat(path.c_str(), &statbuf)) {
-        if (S_ISDIR(statbuf.st_mode)) {
-            DIR *d = opendir(path.c_str());
-            int r = -1;
-            if (d) {
-                struct dirent *p;
-                r = 0;
-                while (!r && (p=readdir(d))) {
-                    /* Skip the names "." and ".." as we don't want to recurse on them. */
-                    if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) continue;
-                    r = removeDirectory(path + "/" + std::string(p->d_name));
-                }
-                closedir(d);
-            }
-            if (!r) r = rmdir(path.c_str());
-            return r;
-        } else return unlink(path.c_str());
-    } else return -1;
-}
-
 void setBasePath(const char * path) {}
 
 void setROMPath(const char * path) {}
 
-std::string getBasePath() {
+path_t getBasePath() {
     return "/user-data";
 }
 
-std::string getROMPath() {
+path_t getROMPath() {
     return "/craftos";
 }
 
-std::string getPlugInPath() {
+path_t getPlugInPath() {
     return "/user-data/plugins";
 }
 
-std::string getMCSavePath() {
+path_t getMCSavePath() {
     return "";
 }
 

--- a/src/platform/ios.mm
+++ b/src/platform/ios.mm
@@ -51,11 +51,11 @@ path_t rom_path_expanded;
 static SDL_SysWMinfo window_info;
 static UIView * sdlView;
 
-void setBasePath(const char * path) {
+void setBasePath(path_t path) {
     base_path_expanded = path;
 }
 
-void setROMPath(const char * path) {
+void setROMPath(path_t path) {
     rom_path_expanded = path;
 }
 

--- a/src/platform/ios.mm
+++ b/src/platform/ios.mm
@@ -46,8 +46,8 @@ extern "C" {
 #include "../terminal/SDLTerminal.hpp"
 
 extern bool exiting;
-std::string base_path_expanded;
-std::string rom_path_expanded;
+path_t base_path_expanded;
+path_t rom_path_expanded;
 static SDL_SysWMinfo window_info;
 static UIView * sdlView;
 
@@ -59,7 +59,7 @@ void setROMPath(const char * path) {
     rom_path_expanded = path;
 }
 
-std::string getBasePath() {
+path_t getBasePath() {
     if (!base_path_expanded.empty()) return base_path_expanded;
     NSArray * paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString * path = paths[0];
@@ -70,7 +70,7 @@ std::string getBasePath() {
     return base_path_expanded;
 }
 
-std::string getROMPath() {
+path_t getROMPath() {
     if (!rom_path_expanded.empty()) return rom_path_expanded;
     NSString * path = [NSBundle mainBundle].resourcePath;
     char * retval = new char[path.length + 1];
@@ -80,7 +80,7 @@ std::string getROMPath() {
     return rom_path_expanded;
 }
 
-std::string getPlugInPath() {
+path_t getPlugInPath() {
     NSString * path = [NSBundle mainBundle].builtInPlugInsPath;
     char * retval = new char[path.length + 1];
     [path getCString:retval maxLength:path.length+1 encoding:NSASCIIStringEncoding];
@@ -89,69 +89,15 @@ std::string getPlugInPath() {
     return s;
 }
 
-std::string getMCSavePath() {
+path_t getMCSavePath() {
     return "";
 }
 
 void setThreadName(std::thread &t, const std::string& name) {}
 
-int createDirectory(const path_t& path) {
-    if (mkdir(path.c_str(), 0777) != 0) {
-        if (errno == ENOENT && path != "/" && !path.empty()) {
-            if (createDirectory(path.substr(0, path.find_last_of('/')).c_str())) return 1;
-            mkdir(path.c_str(), 0777);
-        } else if (errno != EEXIST) return 1;
-    }
-    return 0;
-}
+void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {}
 
-int removeDirectory(const path_t& path) {
-    struct stat statbuf;
-    if (!stat(path.c_str(), &statbuf)) {
-        if (S_ISDIR(statbuf.st_mode)) {
-            DIR *d = opendir(path.c_str());
-            int r = -1;
-            if (d) {
-                struct dirent *p;
-                r = 0;
-                while (!r && (p=readdir(d))) {
-                    /* Skip the names "." and ".." as we don't want to recurse on them. */
-                    if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) continue;
-                    r = removeDirectory(path + "/" + std::string(p->d_name));
-                }
-                closedir(d);
-            }
-            if (!r) r = rmdir(path.c_str());
-            return r;
-        } else return unlink(path.c_str());
-    } else return -1;
-}
-
-unsigned long long getFreeSpace(const path_t& path) {
-    NSDictionary * dict = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[NSString stringWithCString:path.c_str() encoding:NSASCIIStringEncoding] error:nil];
-    if (dict == nil) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getFreeSpace(path.substr(0, path.find_last_of("/")-1));
-    }
-    return [(NSNumber*)dict[NSFileSystemFreeSize] unsignedLongLongValue];
-}
-
-unsigned long long getCapacity(const path_t& path) {
-    NSDictionary * dict = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[NSString stringWithCString:path.c_str() encoding:NSASCIIStringEncoding] error:nil];
-    if (dict == nil) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getCapacity(path.substr(0, path.find_last_of("/")-1));
-    }
-    return [(NSNumber*)dict[NSFileSystemSize] unsignedLongLongValue];
-}
-
-void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {
-    
-}
-
-void migrateOldData() {
-    
-}
+void migrateOldData() {}
 
 void copyImage(SDL_Surface* surf, SDL_Window* win) {
     /*png::solid_pixel_buffer<png::rgb_pixel> pixbuf(surf->w, surf->h);

--- a/src/platform/linux.cpp
+++ b/src/platform/linux.cpp
@@ -43,7 +43,7 @@ extern "C" {
 
 #ifdef CUSTOM_ROM_DIR
 const char * rom_path = CUSTOM_ROM_DIR;
-std::string rom_path_expanded;
+path_t rom_path_expanded;
 #else
 const char * rom_path = "/usr/share/craftos";
 #endif
@@ -52,7 +52,7 @@ const char * base_path = "";
 #else
 const char * base_path = "$XDG_DATA_HOME/craftos-pc";
 #endif
-std::string base_path_expanded;
+path_t base_path_expanded;
 
 void setBasePath(const char * path) {
     base_path = path;
@@ -66,7 +66,7 @@ void setROMPath(const char * path) {
 #endif
 }
 
-std::string getBasePath() {
+path_t getBasePath() {
     if (!base_path_expanded.empty()) return base_path_expanded;
     wordexp_t p;
     wordexp(base_path, &p, 0);
@@ -83,7 +83,7 @@ std::string getBasePath() {
 }
 
 #ifdef CUSTOM_ROM_DIR
-std::string getROMPath() {
+path_t getROMPath() {
     if (!rom_path_expanded.empty()) return rom_path_expanded;
     wordexp_t p;
     wordexp(rom_path, &p, 0);
@@ -93,13 +93,13 @@ std::string getROMPath() {
     return rom_path_expanded;
 }
 
-std::string getPlugInPath() { return getROMPath() + "/plugins/"; }
+path_t getPlugInPath() { return getROMPath() / "plugins"; }
 #else
-std::string getROMPath() { return rom_path; }
-std::string getPlugInPath() { return std::string(rom_path) + "/plugins/"; }
+path_t getROMPath() { return rom_path; }
+path_t getPlugInPath() { return path_t(rom_path) / "plugins"; }
 #endif
 
-std::string getMCSavePath() {
+path_t getMCSavePath() {
     wordexp_t p;
     wordexp("$HOME/.minecraft/saves/", &p, 0);
     std::string expanded = p.we_wordv[0];
@@ -112,58 +112,6 @@ void setThreadName(std::thread &t, const std::string& name) {
     pthread_setname_np(t.native_handle(), name.c_str());
 }
 
-int createDirectory(const std::string& path) {
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0 ) return !S_ISDIR(st.st_mode);
-    if (mkdir(path.c_str(), 0777) != 0) {
-        if (errno == ENOENT && path != "/" && !path.empty()) {
-            if (createDirectory(path.substr(0, path.find_last_of('/')).c_str())) return 1;
-            mkdir(path.c_str(), 0777);
-        } else if (errno != EEXIST) return 1;
-    }
-    return 0;
-}
-
-int removeDirectory(const std::string& path) {
-    struct stat statbuf;
-    if (!stat(path.c_str(), &statbuf)) {
-        if (S_ISDIR(statbuf.st_mode)) {
-            DIR *d = opendir(path.c_str());
-            int r = -1;
-            if (d) {
-                struct dirent *p;
-                r = 0;
-                while (!r && (p=readdir(d))) {
-                    /* Skip the names "." and ".." as we don't want to recurse on them. */
-                    if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) continue;
-                    r = removeDirectory(path + "/" + std::string(p->d_name));
-                }
-                closedir(d);
-            }
-            if (!r) r = rmdir(path.c_str());
-            return r;
-        } else return unlink(path.c_str());
-    } else return -1;
-}
-
-unsigned long long getFreeSpace(const std::string& path) {
-    struct statvfs st;
-    if (statvfs(path.c_str(), &st) != 0) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getFreeSpace(path.substr(0, path.find_last_of("/")-1));
-    }
-    return st.f_bavail * st.f_bsize;
-}
-
-unsigned long long getCapacity(const std::string& path) {
-    struct statvfs st;
-    if (statvfs(path.c_str(), &st) != 0) {
-        if (path.find_last_of("/") == std::string::npos || path.substr(0, path.find_last_of("/")-1).empty()) return 0;
-        else return getCapacity(path.substr(0, path.find_last_of("/")-1));
-    }
-    return st.f_blocks * st.f_frsize;
-}
-
 void updateNow(const std::string& tag_name, const Poco::JSON::Object::Ptr root) {
     
 }
@@ -172,7 +120,7 @@ static int recursiveMove(const std::string& fromDir, const std::string& toDir) {
     struct stat statbuf;
     if (!stat(fromDir.c_str(), &statbuf)) {
         if (S_ISDIR(statbuf.st_mode)) {
-            createDirectory(toDir);
+            fs::create_directories(toDir);
             DIR *d = opendir(fromDir.c_str());
             int r = -1;
             if (d) {

--- a/src/platform/linux.cpp
+++ b/src/platform/linux.cpp
@@ -120,7 +120,9 @@ static int recursiveMove(const std::string& fromDir, const std::string& toDir) {
     struct stat statbuf;
     if (!stat(fromDir.c_str(), &statbuf)) {
         if (S_ISDIR(statbuf.st_mode)) {
-            fs::create_directories(toDir);
+            std::error_code e;
+            fs::create_directories(toDir, e);
+            if (e) return e.value();
             DIR *d = opendir(fromDir.c_str());
             int r = -1;
             if (d) {

--- a/src/platform/linux.cpp
+++ b/src/platform/linux.cpp
@@ -45,7 +45,7 @@ extern "C" {
 const char * rom_path = CUSTOM_ROM_DIR;
 path_t rom_path_expanded;
 #else
-const char * rom_path = "/usr/share/craftos";
+path_t rom_path = "/usr/share/craftos";
 #endif
 #ifdef FS_ROOT
 const char * base_path = "";
@@ -54,15 +54,15 @@ const char * base_path = "$XDG_DATA_HOME/craftos-pc";
 #endif
 path_t base_path_expanded;
 
-void setBasePath(const char * path) {
-    base_path = path;
+void setBasePath(path_t path) {
     base_path_expanded = path;
 }
 
-void setROMPath(const char * path) {
-    rom_path = path;
+void setROMPath(path_t path) {
 #ifdef CUSTOM_ROM_DIR
     rom_path_expanded = path;
+#else
+    rom_path = path;
 #endif
 }
 

--- a/src/platform/macapp.mm
+++ b/src/platform/macapp.mm
@@ -46,18 +46,18 @@ extern "C" {
 
 extern bool exiting;
 path_t rom_path_expanded;
-const char * customBasePath = NULL;
+path_t customBasePath;
 
-void setBasePath(const char * path) {
+void setBasePath(path_t path) {
     customBasePath = path;
 }
 
-void setROMPath(const char * path) {
+void setROMPath(path_t path) {
     rom_path_expanded = path;
 }
 
 path_t getBasePath() {
-    if (customBasePath != NULL) return customBasePath;
+    if (!customBasePath.empty()) return customBasePath;
     return path_t([[[NSFileManager defaultManager] 
                          URLForDirectory:NSApplicationSupportDirectory 
                          inDomain:NSUserDomainMask 

--- a/src/platform/win.cpp
+++ b/src/platform/win.cpp
@@ -39,11 +39,11 @@ path_t base_path_expanded;
 path_t rom_path_expanded;
 wchar_t expand_tmp[32768];
 
-void setBasePath(const char * path) {
+void setBasePath(path_t path) {
     base_path_expanded = path;
 }
 
-void setROMPath(const char * path) {
+void setROMPath(path_t path) {
     rom_path_expanded = path;
 }
 
@@ -237,8 +237,8 @@ static int recursiveMove(const std::wstring& path, const std::wstring& toPath) {
 void migrateOldData() {
     ExpandEnvironmentStringsW(L"%USERPROFILE%\\.craftos", expand_tmp, 32767);
     const std::wstring oldpath = expand_tmp;
-    struct_stat st;
-    if (platform_stat(oldpath.c_str(), &st) == 0 && S_ISDIR(st.st_mode) && platform_stat(getBasePath().c_str(), &st) != 0)
+    struct _stat st;
+    if (_wstat(oldpath.c_str(), &st) == 0 && S_ISDIR(st.st_mode) && _wstat(getBasePath().c_str(), &st) != 0)
         recursiveMove(oldpath, getBasePath());
     if (!failedCopy.empty())
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Migration Failure", "Some files were unable to be moved while migrating the user data directory. These files have been left in place, and they will not appear inside the computer. You can copy them over from the old directory manually.", NULL);
@@ -391,7 +391,7 @@ void uploadCrashDumps() {
             do {
                 std::wstring newpath = std::wstring(path) + find.cFileName;
                 std::stringstream ss;
-                FILE * source = platform_fopen(newpath.c_str(), "rb");
+                FILE * source = _wfopen(newpath.c_str(), L"rb");
 
                 int ret, flush;
                 unsigned have;

--- a/src/platform/win.cpp
+++ b/src/platform/win.cpp
@@ -35,50 +35,37 @@
 #include "../util.hpp"
 
 const wchar_t * base_path = L"%appdata%\\CraftOS-PC";
-std::wstring base_path_expanded;
-std::wstring rom_path_expanded;
-wchar_t expand_tmp[32767];
-static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-
-path_t wstr(std::string str) {
-    try {return converter.from_bytes(str);}
-    catch (std::exception &e) {return L"";}
-}
-
-std::string astr(path_t str) {
-    return converter.to_bytes(str);
-}
-
-FILE* platform_fopen(const wchar_t* path, const char * mode) { return _wfopen(path, wstr(mode).c_str()); }
+path_t base_path_expanded;
+path_t rom_path_expanded;
+wchar_t expand_tmp[32768];
 
 void setBasePath(const char * path) {
-    base_path_expanded = wstr(path);
+    base_path_expanded = path;
 }
 
 void setROMPath(const char * path) {
-    rom_path_expanded = wstr(path);
+    rom_path_expanded = path;
 }
 
-std::wstring getBasePath() {
+path_t getBasePath() {
     if (!base_path_expanded.empty()) return base_path_expanded;
-    ExpandEnvironmentStringsW(base_path, expand_tmp, 32767);
-    base_path_expanded = expand_tmp;
+    ExpandEnvironmentStringsW(base_path, expand_tmp, 32768);
+    base_path_expanded = path_t(expand_tmp, expand_tmp + wcsnlen(expand_tmp, 32768));
     return base_path_expanded;
 }
 
-std::wstring getROMPath() {
+path_t getROMPath() {
     if (!rom_path_expanded.empty()) return rom_path_expanded;
-    GetModuleFileNameW(NULL, expand_tmp, 32767);
-    rom_path_expanded = expand_tmp;
-    rom_path_expanded = rom_path_expanded.substr(0, rom_path_expanded.find_last_of('\\'));
+    GetModuleFileNameW(NULL, expand_tmp, 32768);
+    rom_path_expanded = path_t(expand_tmp, expand_tmp + wcsnlen(expand_tmp, 32768)).parent_path();
     return rom_path_expanded;
 }
 
-std::wstring getPlugInPath() { return getROMPath() + L"\\plugins\\"; }
+path_t getPlugInPath() { return getROMPath() / "plugins"; }
 
-std::wstring getMCSavePath() {
-    ExpandEnvironmentStringsW(L"%appdata%\\.minecraft\\saves\\", expand_tmp, 32767);
-    return std::wstring(expand_tmp);
+path_t getMCSavePath() {
+    ExpandEnvironmentStringsW(L"%appdata%\\.minecraft\\saves\\", expand_tmp, 32768);
+    return path_t(expand_tmp);
 }
 
 void* kernel32handle = NULL;
@@ -90,88 +77,6 @@ void setThreadName(std::thread &t, const std::string& name) {
         _SetThreadDescription = (HRESULT(*)(HANDLE, PCWSTR))SDL_LoadFunction(kernel32handle, "SetThreadDescription");
     }
     if (_SetThreadDescription != NULL) _SetThreadDescription((HANDLE)t.native_handle(), std::wstring(name.begin(), name.end()).c_str());
-}
-
-int createDirectory(const std::wstring& path) {
-    struct_stat st;
-    if (platform_stat(path.c_str(), &st) == 0) return !S_ISDIR(st.st_mode);
-    if (CreateDirectoryExW(path.substr(0, path.find_last_of('\\', path.size() - 2)).c_str(), path.c_str(), NULL) == 0) {
-        if ((GetLastError() == ERROR_PATH_NOT_FOUND || GetLastError() == ERROR_FILE_NOT_FOUND) && path != L"\\" && !path.empty()) {
-            if (createDirectory(path.substr(0, path.find_last_of('\\', path.size() - 2)))) return 1;
-            CreateDirectoryExW(path.substr(0, path.find_last_of('\\', path.size() - 2)).c_str(), path.c_str(), NULL);
-        }
-        else if (GetLastError() != ERROR_ALREADY_EXISTS) return 1;
-    }
-    return 0;
-}
-
-char* basename(char* path) {
-    char* filename = strrchr(path, '/');
-    if (filename == NULL) {
-        filename = strrchr(path, '\\');
-        if (filename == NULL)
-            filename = path;
-        else
-            filename++;
-    } else
-        filename++;
-    return filename;
-}
-
-char* dirname(char* path) {
-    if (path[0] == '/') strcpy(path, &path[1]);
-    char tch;
-    if (strrchr(path, '/') != NULL) tch = '/';
-    else if (strrchr(path, '\\') != NULL) tch = '\\';
-    else return path;
-    path[strrchr(path, tch) - path] = '\0';
-    return path;
-}
-
-unsigned long long getFreeSpace(const std::wstring& path) {
-    ULARGE_INTEGER retval;
-    if (GetDiskFreeSpaceExW(path.substr(0, path.find_last_of('\\', path.size() - 2)).c_str(), &retval, NULL, NULL) == 0) {
-        if (path.find_last_of('\\') == std::string::npos || path.substr(0, path.find_last_of('\\')-1).empty()) return 0;
-        else return getFreeSpace(path.substr(0, path.find_last_of('\\')-1));
-    }
-    return retval.QuadPart;
-}
-
-unsigned long long getCapacity(const std::wstring& path) {
-    ULARGE_INTEGER retval;
-    if (GetDiskFreeSpaceExW(path.substr(0, path.find_last_of('\\', path.size() - 2)).c_str(), NULL, &retval, NULL) == 0) {
-        if (path.find_last_of('\\') == std::string::npos || path.substr(0, path.find_last_of('\\')-1).empty()) return 0;
-        else return getCapacity(path.substr(0, path.find_last_of('\\')-1));
-    }
-    return retval.QuadPart;
-}
-
-int removeDirectory(const std::wstring& path) {
-    const DWORD attr = GetFileAttributesW(path.c_str());
-    if (attr == INVALID_FILE_ATTRIBUTES) return GetLastError();
-    if (attr & FILE_ATTRIBUTE_DIRECTORY) {
-        WIN32_FIND_DATAW find;
-        std::wstring s = path;
-        if (path[path.size() - 1] != '\\') s += L"\\";
-        s += L"*";
-        const HANDLE h = FindFirstFileW(s.c_str(), &find);
-        if (h != INVALID_HANDLE_VALUE) {
-            do {
-                if (!(find.cFileName[0] == '.' && (wcslen(find.cFileName) == 1 || (find.cFileName[1] == '.' && wcslen(find.cFileName) == 2)))) {
-                    std::wstring newpath = path;
-                    if (path[path.size() - 1] != '\\') newpath += L"\\";
-                    newpath += find.cFileName;
-                    const int res = removeDirectory(newpath);
-                    if (res) {
-                        FindClose(h);
-                        return res;
-                    }
-                }
-            } while (FindNextFileW(h, &find));
-            FindClose(h);
-        }
-        return RemoveDirectoryW(path.c_str()) ? 0 : (int)GetLastError();
-    } else return DeleteFileW(path.c_str()) ? 0 : (int)GetLastError();
 }
 
 static std::string makeSize(double n) {
@@ -449,18 +354,18 @@ static bool pushCrashDump(const char * data, const size_t size, const path_t& pa
             if (root.isMember("uploadURL")) {
                 return pushCrashDump(data, size, path, root["uploadURL"].asString(), "PUT");
             } else if (root.isMember("error")) {
-                fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", astr(path).c_str(), root["error"].asString().c_str());
+                fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", path.string().c_str(), root["error"].asString().c_str());
                 return false;
             } else if (root.isMember("message")) {
-                fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", astr(path).c_str(), root["message"].asString().c_str());
+                fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", path.string().c_str(), root["message"].asString().c_str());
                 return false;
             }
         }
     } catch (Poco::Net::SSLException &e) {
-        fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", astr(path).c_str(), e.message().c_str());
+        fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", path.string().c_str(), e.message().c_str());
         return false;
     } catch (Poco::Exception &e) {
-        fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", astr(path).c_str(), e.displayText().c_str());
+        fprintf(stderr, "Warning: Couldn't upload crash dump at %s: %s\n", path.string().c_str(), e.displayText().c_str());
         return false;
     }
     return true;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -318,6 +318,7 @@ bool addMount(Computer *comp, const path_t& real_path, const std::string& comp_p
         if (!read_only && !SDL_AndroidRequestPermission("android.permission.WRITE_EXTERNAL_STORAGE")) return false;
     }
 #endif
+    if (std::regex_search((*real_path.begin()).native(), std::basic_regex<path_t::value_type>(path_t("^\\d+:").native()))) return false;
     if (!fs::is_directory(real_path) || access(real_path.c_str(), R_OK | (read_only ? 0 : W_OK)) != 0) return false;
     std::vector<std::string> elems = split(comp_path, "/\\");
     std::list<std::string> pathc;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -117,7 +117,7 @@ void awaitTasks(const std::function<bool()>& predicate = []()->bool{return true;
             taskQueue->pop();
         }
         SDL_PumpEvents();
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -31,6 +31,7 @@
 #ifdef WIN32
 #define R_OK 0x04
 #define W_OK 0x02
+#define access(p, m) _waccess(p, m)
 #endif
 #ifndef NO_CLI
 #include <csignal>

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -44,14 +44,14 @@ extern std::condition_variable listenerModeNotify;
 
 extern int getNextEvent(lua_State* L, const std::string& filter);
 extern void* queueTask(const std::function<void*(void*)>& func, void* arg, bool async = false);
-extern void runComputer(Computer * self, const path_t& bios_name);
+extern void runComputer(Computer * self, const path_t& bios_name, const std::string& bios_data = "");
 extern bool Computer_getEvent(Computer * self, SDL_Event* e);
 extern Uint32 eventTimeoutEvent(Uint32 interval, void* param);
 extern void* computerThread(void* data);
 extern Computer* startComputer(int id);
 extern void queueEvent(Computer *comp, const event_provider& p, void* data);
-extern bool addMount(Computer *comp, const path_t& real_path, const char * comp_path, bool read_only);
-extern bool addVirtualMount(Computer * comp, const FileEntry& vfs, const char * comp_path);
+extern bool addMount(Computer *comp, const path_t& real_path, const std::string& comp_path, bool read_only);
+extern bool addVirtualMount(Computer * comp, const FileEntry& vfs, const std::string& comp_path);
 extern void registerPeripheral(const std::string& name, const peripheral_init_fn& initializer);
 extern void registerSDLEvent(SDL_EventType type, const sdl_event_handler& handler, void* userdata);
 extern void pumpTaskQueue();

--- a/src/terminal/HardwareSDLTerminal.cpp
+++ b/src/terminal/HardwareSDLTerminal.cpp
@@ -430,7 +430,7 @@ void HardwareSDLTerminal::init() {
     std::string bmp_path = "built-in file";
 #ifndef STANDALONE_ROM
     if (config.customFontPath == "hdfont") {
-        bmp_path = getROMPath() / "hdfont.bmp";
+        bmp_path = (getROMPath() / "hdfont.bmp").string();
         fontScale = 1;
     } else 
 #endif

--- a/src/terminal/HardwareSDLTerminal.cpp
+++ b/src/terminal/HardwareSDLTerminal.cpp
@@ -259,7 +259,7 @@ void HardwareSDLTerminal::render() {
         int w, h;
         if (gotResizeEvent) return;
         if (SDL_GetRendererOutputSize(ren, &w, &h) != 0) return;
-        if (screenshotPath == WS("clipboard")) {
+        if (screenshotPath == "clipboard") {
             SDL_Surface * temp = SDL_CreateRGBSurfaceWithFormat(0, w, h, 24, SDL_PIXELFORMAT_RGB24);
             if (SDL_RenderReadPixels(ren, NULL, SDL_PIXELFORMAT_RGB24, temp->pixels, temp->pitch) != 0) return;
             copyImage(temp, win);
@@ -338,7 +338,11 @@ void HardwareSDLTerminal::render() {
 #endif
                 if (recorderHandle == NULL) {
                     GifWriter * g = new GifWriter;
-                    g->f = platform_fopen(recordingPath.c_str(), "wb");
+#ifdef _WIN32
+                    g->f = _wfopen(recordingPath.native().c_str(), L"wb");
+#else
+                    g->f = fopen(recordingPath.native().c_str(), "wb");
+#endif
                     GifBegin(g, NULL, surf->w, surf->h, 100 / config.recordingFPS);
                     recorderHandle = g;
                 }
@@ -426,7 +430,7 @@ void HardwareSDLTerminal::init() {
     std::string bmp_path = "built-in file";
 #ifndef STANDALONE_ROM
     if (config.customFontPath == "hdfont") {
-        bmp_path = astr(getROMPath() + WS("/hdfont.bmp"));
+        bmp_path = getROMPath() / "hdfont.bmp";
         fontScale = 1;
     } else 
 #endif

--- a/src/terminal/RawTerminal.cpp
+++ b/src/terminal/RawTerminal.cpp
@@ -410,7 +410,7 @@ static std::string rawMouseProvider(lua_State *L, void* data) {
             delete d;
             return "";
         }
-        lua_pushlstring(L, side.c_str(), side.size());
+        pushstring(L, side);
     }
     lua_pushinteger(L, d->x);
     lua_pushinteger(L, d->y);

--- a/src/terminal/SDLTerminal.cpp
+++ b/src/terminal/SDLTerminal.cpp
@@ -615,7 +615,7 @@ void SDLTerminal::init() {
     std::string bmp_path = "built-in file";
 #ifndef STANDALONE_ROM
     if (config.customFontPath == "hdfont") {
-        bmp_path = getROMPath() / "hdfont.bmp";
+        bmp_path = (getROMPath() / "hdfont.bmp").string();
         fontScale = 1;
     } else 
 #endif

--- a/src/terminal/SDLTerminal.cpp
+++ b/src/terminal/SDLTerminal.cpp
@@ -497,7 +497,9 @@ void SDLTerminal::screenshot(std::string path) {
         time_t now = time(0);
         struct tm * nowt = localtime(&now);
         screenshotPath = getBasePath() / "screenshots";
-        fs::create_directories(screenshotPath);
+        std::error_code e;
+        fs::create_directories(screenshotPath, e);
+        if (e) return;
         char tstr[24];
         strftime(tstr, 24, "%F_%H.%M.%S", nowt);
         tstr[23] = '\0';
@@ -522,7 +524,9 @@ void SDLTerminal::record(std::string path) {
         time_t now = time(0);
         struct tm * nowt = localtime(&now);
         recordingPath = getBasePath() / "screenshots";
-        fs::create_directories(recordingPath);
+        std::error_code e;
+        fs::create_directories(recordingPath, e);
+        if (e) return;
         char tstr[20];
         strftime(tstr, 20, "%F_%H.%M.%S", nowt);
         isRecordingWebP = config.useWebP;

--- a/src/termsupport.cpp
+++ b/src/termsupport.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <Terminal.hpp>
 #include "apis.hpp"
+#include "main.hpp"
 #include "runtime.hpp"
 #include "peripheral/monitor.hpp"
 #include "peripheral/debugger.hpp"
@@ -338,6 +339,7 @@ int termPanic(lua_State *L) {
         lua_close(comp->rawFileStack);
         comp->rawFileStack = NULL;
     }
+    if (selectedRenderer == 1) returnValue = 1;
     longjmp(comp->on_panic, 0);
 }
 

--- a/src/termsupport.cpp
+++ b/src/termsupport.cpp
@@ -872,7 +872,7 @@ std::string termGetEvent(lua_State *L) {
             if (config.dropFilePath) {
                 // Simply paste the file path
                 // Look for a path relative to a mount; if not then just give it the whole thing
-                path_t::string_type path = e.drop.file;
+                path_t::string_type path = path_t(e.drop.file).native();
                 std::string path_final = e.drop.file;
                 path_t::string_type::iterator largestMatch = path.begin();
                 {
@@ -896,7 +896,7 @@ std::string termGetEvent(lua_State *L) {
                 return "paste";
             } else {
                 // Copy the file into the computer
-                path_t path = fixpath(computer, basename(e.drop.file), false);
+                path_t path(e.drop.file);
                 if (fs::is_regular_file(path)) {
                     SDLTerminal * term = dynamic_cast<SDLTerminal*>(computer->term);
                     if (term != NULL) {
@@ -941,9 +941,9 @@ std::string termGetEvent(lua_State *L) {
                 }
                 char buf[4096];
                 while (!infile.eof()) {
-                    size_t sz = infile.readsome(buf, 4096);
-                    outfile.write(buf, sz);
-                    if (sz < 4096) break;
+                    infile.read(buf, 4096);
+                    outfile.write(buf, infile.gcount());
+                    if (infile.gcount() < 4096) break;
                 }
                 infile.close();
                 outfile.close();

--- a/src/termsupport.cpp
+++ b/src/termsupport.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <chrono>
 #include <codecvt>
+#include <fstream>
 #include <locale>
 #include <queue>
 #include <unordered_map>
@@ -726,7 +727,7 @@ std::string termGetEvent(lua_State *L) {
                 try {str = utf8_to_string(text, std::locale("C"));}
                 catch (std::exception &e) {return "";}
                 str = str.substr(0, min(str.find_first_of("\r\n"), (std::string::size_type)512));
-                lua_pushlstring(L, str.c_str(), str.size());
+                pushstring(L, str);
                 SDL_free(text);
                 return "paste";
             } else computer->waitingForTerminate = 0;
@@ -871,13 +872,13 @@ std::string termGetEvent(lua_State *L) {
             if (config.dropFilePath) {
                 // Simply paste the file path
                 // Look for a path relative to a mount; if not then just give it the whole thing
-                path_t path = wstr(e.drop.file);
+                path_t::string_type path = e.drop.file;
                 std::string path_final = e.drop.file;
-                path_t::iterator largestMatch = path.begin();
+                path_t::string_type::iterator largestMatch = path.begin();
                 {
                     auto match = std::mismatch(path.begin(), path.end(), computer->dataDir.begin());
                     if (match.first > largestMatch) {
-                        path_final = astr(path_t(match.first + 1, path.end()));
+                        path_final = path_t(match.first + 1, path.end()).string();
                         largestMatch = match.first;
                     }
                 }
@@ -886,44 +887,41 @@ std::string termGetEvent(lua_State *L) {
                     if (match.first > largestMatch) {
                         path_final = "";
                         for (const std::string& c : std::get<0>(m)) path_final += c + "/";
-                        path_final += astr(path_t(match.first + 1, path.end()));
+                        path_final += path_t(match.first + 1, path.end()).string();
                         largestMatch = match.first;
                     }
                 }
-                lua_pushfstring(L, "%s ", astr(fixpath(computer, path_final, false, false)).c_str());
+                lua_pushfstring(L, "%s ", fixpath(computer, path_final, false, false).string().c_str());
                 SDL_free(e.drop.file);
                 return "paste";
             } else {
                 // Copy the file into the computer
                 path_t path = fixpath(computer, basename(e.drop.file), false);
-                struct_stat st;
-                if (platform_stat(path.c_str(), &st) == 0) {
-                    if (S_ISREG(st.st_mode)) {
-                        SDLTerminal * term = dynamic_cast<SDLTerminal*>(computer->term);
-                        if (term != NULL) {
-                            SDL_MessageBoxButtonData buttons[] = {
-                                {SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No"},
-                                {0, 1, "Yes"}
-                            };
-                            std::string text = std::string("A file named ") + basename(e.drop.file) + " already exists on this computer. Would you like to overwrite it?";
-                            SDL_MessageBoxData msg = {
-                                SDL_MESSAGEBOX_WARNING,
-                                term->win,
-                                "File already exists",
-                                text.c_str(),
-                                2,
-                                buttons,
-                                NULL
-                            };
-                            if (!queueTask([](void*msg)->void*{int b = 0; SDL_ShowMessageBox((SDL_MessageBoxData*)msg, &b); return (void*)(ptrdiff_t)b;}, &msg)) {
-                                SDL_free(e.drop.file);
-                                return "";
-                            }
+                if (fs::is_regular_file(path)) {
+                    SDLTerminal * term = dynamic_cast<SDLTerminal*>(computer->term);
+                    if (term != NULL) {
+                        SDL_MessageBoxButtonData buttons[] = {
+                            {SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No"},
+                            {0, 1, "Yes"}
+                        };
+                        std::string text = std::string("A file named ") + path.filename().string() + " already exists on this computer. Would you like to overwrite it?";
+                        SDL_MessageBoxData msg = {
+                            SDL_MESSAGEBOX_WARNING,
+                            term->win,
+                            "File already exists",
+                            text.c_str(),
+                            2,
+                            buttons,
+                            NULL
+                        };
+                        if (!queueTask([](void*msg)->void*{int b = 0; SDL_ShowMessageBox((SDL_MessageBoxData*)msg, &b); return (void*)(ptrdiff_t)b;}, &msg)) {
+                            SDL_free(e.drop.file);
+                            return "";
                         }
                     }
                 }
-                FILE * infile = fopen(e.drop.file, "rb");
-                if (infile == NULL) {
+                std::ifstream infile(e.drop.file, std::ios::binary);
+                if (!infile.is_open()) {
                     char * err = strerror(errno);
                     char * msg = new char[strlen(err)+1];
                     strcpy(msg, err);
@@ -931,24 +929,24 @@ std::string termGetEvent(lua_State *L) {
                     SDL_free(e.drop.file);
                     return "";
                 }
-                FILE * outfile = platform_fopen(path.c_str(), "wb");
-                if (outfile == NULL) {
+                std::ofstream outfile(path, std::ios::binary);
+                if (!outfile.is_open()) {
                     char * err = strerror(errno);
                     char * msg = new char[strlen(err)+1];
                     strcpy(msg, err);
                     queueTask([computer](void*msg)->void*{computer->term->showMessage(SDL_MESSAGEBOX_ERROR, "Upload Failed", (std::string("The output file could not be written: ") + (const char*)msg + ".").c_str()); delete[] (char*)msg; return NULL;}, msg, true);
-                    fclose(infile);
+                    infile.close();
                     SDL_free(e.drop.file);
                     return "";
                 }
                 char buf[4096];
-                while (!feof(infile)) {
-                    size_t sz = fread(buf, 1, 4096, infile);
-                    fwrite(buf, 1, sz, outfile);
+                while (!infile.eof()) {
+                    size_t sz = infile.readsome(buf, 4096);
+                    outfile.write(buf, sz);
                     if (sz < 4096) break;
                 }
-                fclose(infile);
-                fclose(outfile);
+                infile.close();
+                outfile.close();
                 computer->fileUploadCount++;
                 SDL_free(e.drop.file);
                 return "";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -212,9 +212,7 @@ path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt
             for (const _path_t& p : max_path.second) {
                 path_t sstmp = p;
                 for (const std::string& s : pathc) sstmp /= s;
-                if (
-                    (isVFSPath(p) && nothrow(comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(sstmp.string()))) ||
-                    (fs::exists(sstmp))) {
+                if ((isVFSPath(p) && nothrow(comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(sstmp))) || (fs::exists(sstmp))) {
                     ss /= sstmp;
                     found = true;
                     break;
@@ -231,8 +229,7 @@ path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt
                 if (
                     (isVFSPath(p) && (nothrow(comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(ss/back)) ||
                     (nothrow(comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(sstmp)) && comp->virtualMounts[(unsigned)std::stoul(p.substr(0, p.size()-1))]->path(sstmp).isDir))) ||
-                    (fs::exists(sstmp/back)) || (fs::is_directory(sstmp))
-                    ) {
+                    (fs::exists(sstmp/back)) || (fs::is_directory(sstmp))) {
                     ss /= sstmp/back;
                     found = true;
                     break;
@@ -255,6 +252,11 @@ path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt
             }
         }
     } else for (const std::string& s : pathc) ss /= s;
+    if (path_t::preferred_separator != (path_t::value_type)'/' && (!addExt || isVFSPath(ss))) {
+        path_t::string_type str = ss.native();
+        std::replace(str.begin(), str.end(), path_t::preferred_separator, (path_t::value_type)'/');
+        ss = path_t(str);
+    }
     return ss;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -186,7 +186,7 @@ path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt
     while (!pathc.empty() && pathc.front().empty()) pathc.pop_front();
     if (comp->isDebugger && addExt && pathc.size() == 1 && pathc.front() == "bios.lua")
 #ifdef STANDALONE_ROM
-        return path_t(":bios.lua", path::format::generic_format);
+        return path_t(":bios.lua", path_t::format::generic_format);
 #else
         return getROMPath()/"bios.lua";
 #endif

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -15,6 +15,7 @@ extern "C" {
 #include <lua.h>
 #include <lauxlib.h>
 }
+#include <filesystem>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -28,6 +29,9 @@ extern "C" {
 #define CRAFTOSPC_VERSION    "v2.6.7"
 #define CRAFTOSPC_CC_VERSION "1.100.8"
 #define CRAFTOSPC_INDEV      true
+
+using path_t = std::filesystem::path;
+namespace fs = std::filesystem;
 
 // for some reason Clang complains if this isn't present
 #ifdef __clang__
@@ -191,14 +195,6 @@ inline std::string asciify(std::string str) {
     return retval;
 }
 
-#ifdef WIN32
-#define PATH_SEP L"\\"
-#define PATH_SEPC '\\'
-#else
-#define PATH_SEP "/"
-#define PATH_SEPC '/'
-#endif
-
 extern struct configuration config;
 extern std::unordered_map<std::string, std::pair<int, int> > configSettings;
 extern std::unordered_map<std::string, std::tuple<int, std::function<int(const std::string&, void*)>, void*> > userConfig;
@@ -216,9 +212,10 @@ extern std::string b64encode(const std::string& orig);
 extern std::string b64decode(const std::string& orig);
 extern std::vector<std::string> split(const std::string& strToSplit, const char * delimeter);
 extern std::vector<std::wstring> split(const std::wstring& strToSplit, const wchar_t * delimeter);
+extern std::vector<path_t> split(const path_t& strToSplit, const path_t::value_type * delimeter);
 extern void load_library(Computer *comp, lua_State *L, const library_t& lib);
 extern void HTTPDownload(const std::string& url, const std::function<void(std::istream*, Poco::Exception*, Poco::Net::HTTPResponse*)>& callback);
-extern path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt = true, std::string * mountPath = NULL, bool getAllResults = false, bool * isRoot = NULL);
+extern path_t fixpath(Computer *comp, const std::string& path, bool exists, bool addExt = true, std::string * mountPath = NULL, bool * isRoot = NULL);
 extern bool fixpath_ro(Computer *comp, const std::string& path);
 extern path_t fixpath_mkdir(Computer * comp, const std::string& path, bool md = true, std::string * mountPath = NULL);
 extern std::set<std::string> getMounts(Computer * computer, const std::string& comp_path);
@@ -228,7 +225,6 @@ extern void setComputerConfig(int id, const computer_configuration& cfg);
 extern void config_init();
 extern void config_save();
 extern void xcopy(lua_State *from, lua_State *to, int n);
-extern std::pair<int, std::string> recursiveCopy(const path_t& fromPath, const path_t& toPath, std::list<path_t> * failures = NULL);
 extern std::string makeASCIISafe(const char * retval, size_t len);
 extern bool matchIPClass(const std::string& address, const std::string& pattern);
 inline std::string checkstring(lua_State *L, int idx) {
@@ -242,5 +238,6 @@ inline std::string tostring(lua_State *L, int idx, const std::string& def = "") 
     if (str == NULL) return def;
     return std::string(str, sz);
 }
+inline void pushstring(lua_State *L, const std::string& str) {pushstring(L, str);}
 
 #endif

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -26,7 +26,7 @@ extern "C" {
 #include <Computer.hpp>
 #include <Terminal.hpp>
 
-#define CRAFTOSPC_VERSION    "v2.6.7"
+#define CRAFTOSPC_VERSION    "v2.7"
 #define CRAFTOSPC_CC_VERSION "1.100.8"
 #define CRAFTOSPC_INDEV      true
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -39,8 +39,9 @@ template<> class std::hash<SDL_EventType>: public std::hash<unsigned short> {};
 #endif
 
 // for old compilers (see C++ LWG 3657)
-// NOTE: The libc++ and MSVC checks will *definitely* fail in the future! Check this once libc++/MSVC resolve the issue.
-#if (defined(__GLIBCXX__) && __GLIBCXX__ < 20220426) || (defined(_LIBCPP_VERSION) /*&& _LIBCPP_VERSION < 16000*/) || (defined(_MSC_FULL_VER) /*&& _MSC_FULL_VER < 193200000*/)
+// NOTE: The libc++ check will *definitely* fail in the future! Check this once libc++ resolve the issue.
+// NOTE: No idea if this MSVC check is correct - if you have issues, just update to the latest VS2022.
+#if (defined(__GLIBCXX__) && __GLIBCXX__ < 20220426) || (defined(_LIBCPP_VERSION) /*&& _LIBCPP_VERSION < 16000*/) || (defined(_MSC_FULL_VER) && _MSC_FULL_VER < 193200000)
 template<> struct std::hash<path_t> {size_t operator()(const path_t& path) const noexcept {return fs::hash_value(path);}};
 #endif
 
@@ -244,6 +245,6 @@ inline std::string tostring(lua_State *L, int idx, const std::string& def = "") 
     if (str == NULL) return def;
     return std::string(str, sz);
 }
-inline void pushstring(lua_State *L, const std::string& str) {pushstring(L, str);}
+inline void pushstring(lua_State *L, const std::string& str) {lua_pushlstring(L, str.c_str(), str.size());}
 
 #endif

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -38,6 +38,12 @@ namespace fs = std::filesystem;
 template<> class std::hash<SDL_EventType>: public std::hash<unsigned short> {};
 #endif
 
+// for old compilers (see C++ LWG 3657)
+// NOTE: The libc++ and MSVC checks will *definitely* fail in the future! Check this once libc++/MSVC resolve the issue.
+#if (defined(__GLIBCXX__) && __GLIBCXX__ < 20220426) || (defined(_LIBCPP_VERSION) /*&& _LIBCPP_VERSION < 16000*/) || (defined(_MSC_FULL_VER) /*&& _MSC_FULL_VER < 193200000*/)
+template<> struct std::hash<path_t> {size_t operator()(const path_t& path) const noexcept {return fs::hash_value(path);}};
+#endif
+
 template<typename T>
 class ProtectedObject {
     friend class LockGuard;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "craftos-pc",
-    "version-string": "v2.6",
+    "version-string": "v2.7",
     "description": "Advanced ComputerCraft emulator",
     "dependencies": [
         "sdl2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,10 +11,6 @@
             "features": [ "netssl" ]
         },
         {
-            "name": "dirent",
-            "platform": "windows"
-        },
-        {
             "name": "zlib",
             "platform": "windows"
         }


### PR DESCRIPTION
This PR rewrites the core filesystem functionality to use the `std::filesystem` API introduced in C++17. This allows for greater cross-platform access and less need for platform-specific code. It also reduces possible bugs when using low-level APIs, and consolidates the old `FILE*` and new `std::istream` file handles into just one set of functions. Finally, it replaces `path_t` with `std::filesystem::path`, which provides a bunch of easy methods to quickly manipulate paths, including getting filenames, parent directories, and combining parts, all without needing to worry about path separators.

This does end up breaking on systems that lack C++17 support, so Ubuntu 18.04 will no longer be supported due to missing G++ 8. It also introduces a little bit of mess in the API, as the `Computer` class uses the old `path_t` type, so replacing it with `std::filesystem::path` will break the ABI. Therefore, internal functions that use these fields will have to switch between `path_t` and `std::filesystem::path` - thankfully, `path_t` -> `std::filesystem::path` is automatic, so there isn't too much mess there.

This PR also updates the Visual Studio project to 2022, as 2019 did not have a hash overload for `std::filesystem::path`, causing some slight overhead (which is still present anyway for older compilers). It also updates the version number to v2.7.

Closes: #206 