### PR TITLE
Generic peripherals

### DIFF
--- a/CraftOS-PC 2.vcxproj
+++ b/CraftOS-PC 2.vcxproj
@@ -638,14 +638,17 @@
     <ClInclude Include="src\gif.hpp" />
     <ClInclude Include="src\main.hpp" />
     <ClInclude Include="src\runtime.hpp" />
+    <ClInclude Include="src\peripheral\chest.hpp" />
     <ClInclude Include="src\peripheral\computer.hpp" />
     <ClInclude Include="src\peripheral\debugger.hpp" />
     <ClInclude Include="src\peripheral\debug_adapter.hpp" />
     <ClInclude Include="src\peripheral\drive.hpp" />
+    <ClInclude Include="src\peripheral\energy.hpp" />
     <ClInclude Include="src\peripheral\modem.hpp" />
     <ClInclude Include="src\peripheral\monitor.hpp" />
     <ClInclude Include="src\peripheral\printer.hpp" />
     <ClInclude Include="src\peripheral\speaker.hpp" />
+    <ClInclude Include="src\peripheral\tank.hpp" />
     <ClInclude Include="src\platform.hpp" />
     <ClInclude Include="src\platform\resource.h" />
     <ClInclude Include="src\termsupport.hpp" />
@@ -693,10 +696,12 @@
     <ClCompile Include="src\util.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\runtime.cpp" />
+    <ClCompile Include="src\peripheral\chest.cpp" />
     <ClCompile Include="src\peripheral\computer_p.cpp" />
     <ClCompile Include="src\peripheral\debugger.cpp" />
     <ClCompile Include="src\peripheral\debug_adapter.cpp" />
     <ClCompile Include="src\peripheral\drive.cpp" />
+    <ClCompile Include="src\peripheral\energy.cpp" />
     <ClCompile Include="src\peripheral\modem.cpp" />
     <ClCompile Include="src\peripheral\monitor.cpp" />
     <ClCompile Include="src\peripheral\printer.cpp" />
@@ -723,6 +728,7 @@
       <MinimalRebuild Condition="'$(Configuration)|$(Platform)'=='ReleaseStandalone|ARM64'">
       </MinimalRebuild>
     </ClCompile>
+    <ClCompile Include="src\peripheral\tank.cpp" />
     <ClCompile Include="src\platform.cpp" />
     <ClCompile Include="src\platform\darwin.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>

--- a/CraftOS-PC 2.vcxproj.filters
+++ b/CraftOS-PC 2.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClInclude Include="src\terminal\TRoRTerminal.hpp">
       <Filter>Header Files\terminal</Filter>
     </ClInclude>
+    <ClInclude Include="src\peripheral\chest.hpp">
+      <Filter>Header Files\peripheral</Filter>
+    </ClInclude>
     <ClInclude Include="src\peripheral\computer.hpp">
       <Filter>Header Files\peripheral</Filter>
     </ClInclude>
@@ -145,6 +148,9 @@
     <ClInclude Include="src\peripheral\drive.hpp">
       <Filter>Header Files\peripheral</Filter>
     </ClInclude>
+    <ClInclude Include="src\peripheral\energy.hpp">
+      <Filter>Header Files\peripheral</Filter>
+    </ClInclude>
     <ClInclude Include="src\peripheral\modem.hpp">
       <Filter>Header Files\peripheral</Filter>
     </ClInclude>
@@ -155,6 +161,9 @@
       <Filter>Header Files\peripheral</Filter>
     </ClInclude>
     <ClInclude Include="src\peripheral\speaker.hpp">
+      <Filter>Header Files\peripheral</Filter>
+    </ClInclude>
+    <ClInclude Include="src\peripheral\tank.hpp">
       <Filter>Header Files\peripheral</Filter>
     </ClInclude>
     <ClInclude Include="src\platform\resource.h">
@@ -249,6 +258,9 @@
     <ClCompile Include="src\platform\win.cpp">
       <Filter>Source Files\platform</Filter>
     </ClCompile>
+    <ClCompile Include="src\peripheral\chest.cpp">
+      <Filter>Source Files\peripheral</Filter>
+    </ClCompile>
     <ClCompile Include="src\peripheral\computer_p.cpp">
       <Filter>Source Files\peripheral</Filter>
     </ClCompile>
@@ -259,6 +271,9 @@
       <Filter>Source Files\peripheral</Filter>
     </ClCompile>
     <ClCompile Include="src\peripheral\drive.cpp">
+      <Filter>Source Files\peripheral</Filter>
+    </ClCompile>
+    <ClCompile Include="src\peripheral\energy.cpp">
       <Filter>Source Files\peripheral</Filter>
     </ClCompile>
     <ClCompile Include="src\peripheral\modem.cpp">
@@ -274,6 +289,9 @@
       <Filter>Source Files\peripheral</Filter>
     </ClCompile>
     <ClCompile Include="src\peripheral\speaker_sounds.cpp">
+      <Filter>Source Files\peripheral</Filter>
+    </ClCompile>
+    <ClCompile Include="src\peripheral\tank.cpp">
       <Filter>Source Files\peripheral</Filter>
     </ClCompile>
     <ClCompile Include="src\terminal\CLITerminal.cpp">

--- a/Makefile.in
+++ b/Makefile.in
@@ -32,7 +32,7 @@ IDIR=@srcdir@/api
 ODIR=obj
 _OBJ=Computer.o configuration.o favicon.o font.o gif.o main.o plugin.o runtime.o speaker_sounds.o termsupport.o util.o \
 	 apis_config.o apis_fs.o apis_fs_handle.o @HTTP_TARGET@ apis_mounter.o apis_os.o apis_periphemu.o apis_peripheral.o apis_redstone.o apis_term.o \
-	 peripheral_monitor.o peripheral_printer.o peripheral_computer.o peripheral_modem.o peripheral_drive.o peripheral_debugger.o peripheral_debug_adapter.o peripheral_speaker.o \
+	 peripheral_monitor.o peripheral_printer.o peripheral_computer.o peripheral_modem.o peripheral_drive.o peripheral_debugger.o peripheral_debug_adapter.o peripheral_speaker.o peripheral_chest.o \
 	 terminal_SDLTerminal.o terminal_CLITerminal.o terminal_RawTerminal.o terminal_TRoRTerminal.o terminal_HardwareSDLTerminal.o @OBJS@
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -32,7 +32,8 @@ IDIR=@srcdir@/api
 ODIR=obj
 _OBJ=Computer.o configuration.o favicon.o font.o gif.o main.o plugin.o runtime.o speaker_sounds.o termsupport.o util.o \
 	 apis_config.o apis_fs.o apis_fs_handle.o @HTTP_TARGET@ apis_mounter.o apis_os.o apis_periphemu.o apis_peripheral.o apis_redstone.o apis_term.o \
-	 peripheral_monitor.o peripheral_printer.o peripheral_computer.o peripheral_modem.o peripheral_drive.o peripheral_debugger.o peripheral_debug_adapter.o peripheral_speaker.o peripheral_chest.o \
+	 peripheral_monitor.o peripheral_printer.o peripheral_computer.o peripheral_modem.o peripheral_drive.o peripheral_debugger.o \
+	 peripheral_debug_adapter.o peripheral_speaker.o peripheral_chest.o peripheral_energy.o peripheral_tank.o \
 	 terminal_SDLTerminal.o terminal_CLITerminal.o terminal_RawTerminal.o terminal_TRoRTerminal.o terminal_HardwareSDLTerminal.o @OBJS@
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 

--- a/api/generic_peripheral/energy_storage.hpp
+++ b/api/generic_peripheral/energy_storage.hpp
@@ -14,14 +14,15 @@
 #include "../peripheral.hpp"
 
 class energy_storage : public peripheral {
+protected:
     virtual int getEnergy() = 0; // Returns the current energy of the peripheral.
     virtual int getEnergyCapacity() = 0; // Returns the total energy capacity of the peripheral.
 public:
-    int call(lua_State *L, const char * method) override {
+    virtual int call(lua_State *L, const char * method) override {
         const std::string m(method);
         if (m == "getEnergy") lua_pushinteger(L, getEnergy());
         else if (m == "getEnergyCapacity") lua_pushinteger(L, getEnergyCapacity());
-        else return 0;
+        else return luaL_error(L, "No such method");
         return 1;
     }
     void update() override {}

--- a/api/generic_peripheral/fluid_storage.hpp
+++ b/api/generic_peripheral/fluid_storage.hpp
@@ -15,11 +15,12 @@
 #include "../peripheral.hpp"
 
 class fluid_storage : public peripheral {
+protected:
     virtual int tanks(lua_State *L) = 0; // Implements tanks() as a Lua function: https://tweaked.cc/generic_peripheral/fluid_storage.html#v:tanks
     virtual int addFluid(const std::string& fluid, int amount) = 0; // Adds the specified amount of fluid to a tank. Returns the amount actually added.
     virtual std::list<std::pair<std::string, int>> removeFluid(const std::string& fluid, int amount) = 0; // Removes the specified amount of fluid from a tank. If fluid is empty, remove any type of fluid; otherwise only remove that type. Returns a list of each fluid type & amount removed. (If no fluid is removed, return an empty list.)
 public:
-    int call(lua_State *L, const char * method) override {
+    virtual int call(lua_State *L, const char * method) override {
         const std::string m(method);
         if (m == "tanks") return tanks(L);
         else if (m == "pushFluid" || m == "pullFluid") {
@@ -52,7 +53,7 @@ public:
 
             lua_pushinteger(L, added);
             return 1;
-        } else return 0;
+        } else return luaL_error(L, "No such method");
     }
     void update() override {}
     library_t getMethods() const override {

--- a/api/generic_peripheral/inventory.hpp
+++ b/api/generic_peripheral/inventory.hpp
@@ -81,7 +81,7 @@ public:
 
             lua_pushinteger(L, added);
             return 1;
-        } else return 0;
+        } else return luaL_error(L, "No such method");
     }
     void update() override {}
     virtual library_t getMethods() const override {

--- a/api/generic_peripheral/inventory.hpp
+++ b/api/generic_peripheral/inventory.hpp
@@ -15,12 +15,13 @@
 #include "../peripheral.hpp"
 
 class inventory : public peripheral {
+protected:
     virtual int size() = 0; // Returns the number of slots available in the inventory.
     virtual void getItemDetail(lua_State *L, int slot) = 0; // Pushes a single Lua value to the stack with details about an item in a slot. If the slot is empty or invalid, pushes nil. (Slots are in the range 1-size().)
     virtual int addItems(lua_State *L, int slot, int count) = 0; // Adds the item described at the top of the Lua stack to the slot selected. Only adds up to count items. If slot is 0, determine the best slot available. Returns the number of items added.
     virtual int removeItems(int slot, int count) = 0; // Removes up to a number of items from the selected slot. Returns the number of items removed.
 public:
-    int call(lua_State *L, const char * method) override {
+    virtual int call(lua_State *L, const char * method) override {
         const std::string m(method);
         if (m == "size") {
             lua_pushinteger(L, size());
@@ -29,7 +30,19 @@ public:
             lua_createtable(L, size(), 0);
             for (int i = 1; i <= size(); i++) {
                 lua_pushinteger(L, i);
+                lua_createtable(L, 0, 3);
                 getItemDetail(L, i);
+                if (lua_istable(L, -1)) {
+                    lua_getfield(L, -1, "name");
+                    lua_setfield(L, -3, "name");
+                    lua_getfield(L, -1, "count");
+                    lua_setfield(L, -3, "count");
+                    lua_getfield(L, -1, "nbt");
+                    lua_setfield(L, -3, "nbt");
+                    lua_pop(L, 1);
+                } else {
+                    lua_remove(L, -2);
+                }
                 lua_settable(L, -3);
             }
             return 1;
@@ -71,7 +84,7 @@ public:
         } else return 0;
     }
     void update() override {}
-    library_t getMethods() const override {
+    virtual library_t getMethods() const override {
         static luaL_Reg reg[] = {
             {"size", NULL},
             {"list", NULL},

--- a/src/apis/periphemu.cpp
+++ b/src/apis/periphemu.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <Computer.hpp>
 #include <Terminal.hpp>
+#include "../peripheral/chest.hpp"
 #include "../peripheral/computer.hpp"
 #include "../peripheral/debugger.hpp"
 #include "../peripheral/debug_adapter.hpp"
@@ -30,6 +31,8 @@ static std::unordered_map<std::string, peripheral_init_fn> initializers = {
     {"printer", peripheral_init_fn(printer::init)},
     {"modem", peripheral_init_fn(modem::init)},
     {"drive", peripheral_init_fn(drive::init)},
+    {"chest", peripheral_init_fn(chest::init)},
+    {"minecraft:chest", peripheral_init_fn(chest::init)},
 #ifndef NO_MIXER
     {"speaker", peripheral_init_fn(speaker::init)}
 #endif

--- a/src/apis/periphemu.cpp
+++ b/src/apis/periphemu.cpp
@@ -16,10 +16,12 @@
 #include "../peripheral/debugger.hpp"
 #include "../peripheral/debug_adapter.hpp"
 #include "../peripheral/drive.hpp"
+#include "../peripheral/energy.hpp"
 #include "../peripheral/modem.hpp"
 #include "../peripheral/monitor.hpp"
 #include "../peripheral/printer.hpp"
 #include "../peripheral/speaker.hpp"
+#include "../peripheral/tank.hpp"
 #include "../runtime.hpp"
 #include "../util.hpp"
 
@@ -33,6 +35,8 @@ static std::unordered_map<std::string, peripheral_init_fn> initializers = {
     {"drive", peripheral_init_fn(drive::init)},
     {"chest", peripheral_init_fn(chest::init)},
     {"minecraft:chest", peripheral_init_fn(chest::init)},
+    {"energy", peripheral_init_fn(energy::init)},
+    {"tank", peripheral_init_fn(tank::init)},
 #ifndef NO_MIXER
     {"speaker", peripheral_init_fn(speaker::init)}
 #endif

--- a/src/peripheral/chest.cpp
+++ b/src/peripheral/chest.cpp
@@ -1,0 +1,88 @@
+/*
+ * peripheral/chest.cpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the methods for the chests peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows.
+ */
+
+#include "chest.hpp"
+
+int chest::size() {
+    if (isDouble) return 54;
+    else return 27;
+}
+
+void chest::getItemDetail(lua_State *L, int slot) {
+    if (slot < 1 || slot > (isDouble ? 54 : 27)) {lua_pushnil(L); return;}
+    lua_createtable(L, 0, 2);
+    lua_pushlstring(L, items[slot-1].name.c_str(), items[slot-1].name.size());
+    lua_setfield(L, -2, "name");
+    lua_pushinteger(L, items[slot-1].count);
+    lua_setfield(L, -2, "count");
+}
+
+int chest::addItems(lua_State *L, int slot, int count) {
+    lua_getfield(L, -1, "name");
+    if (!lua_isstring(L, -1)) {
+        lua_pop(L, 1);
+        return 0;
+    }
+    std::string name = tostring(L, -1);
+    lua_pop(L, 1);
+    if (slot == 0) for (slot = 1; slot <= (isDouble ? 54 : 27) && items[slot-1].count > 0 && items[slot-1].name != name; slot++);
+    if (slot < 0 || slot > (isDouble ? 54 : 27) || (items[slot-1].name != name && !items[slot-1].name.empty())) return 0;
+    uint8_t d = min(items[slot-1].count + count, 64) - items[slot-1].count;
+    if (d > 0) items[slot-1].name = name;
+    items[slot-1].count += d;
+    return d;
+}
+
+int chest::removeItems(int slot, int count) {
+    if (slot < 0 || slot > (isDouble ? 54 : 27) || count <= 0) return 0;
+    count = min(count, (int)items[slot-1].count);
+    items[slot-1].count -= count;
+    if (items[slot-1].count == 0) items[slot-1].name = "";
+    return count;
+}
+
+int chest::setItem(lua_State *L) {
+    int slot = luaL_checknumber(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+    lua_getfield(L, 2, "name");
+    if (!lua_isstring(L, -1)) luaL_error(L, "bad field 'name' (expected string, got %s)", lua_typename(L, lua_type(L, -1)));
+    lua_pop(L, 1);
+    lua_getfield(L, 2, "count");
+    if (!lua_isnumber(L, -1)) luaL_error(L, "bad field 'name' (expected string, got %s)", lua_typename(L, lua_type(L, -1)));
+    int count = lua_tointeger(L, -1);
+    lua_settop(L, 2);
+    lua_pushinteger(L, addItems(L, slot, count));
+    return 1;
+}
+
+chest::chest(lua_State *L, const char * side) {
+    if (lua_toboolean(L, 3)) isDouble = true;
+}
+
+chest::~chest() {}
+
+int chest::call(lua_State *L, const char * method) {
+    const std::string m(method);
+    if (m == "setItem") return setItem(L);
+    else return inventory::call(L, method);
+}
+
+static luaL_Reg chest_reg[] = {
+    {"size", NULL},
+    {"list", NULL},
+    {"getItemDetail", NULL},
+    {"pushItems", NULL},
+    {"pullItems", NULL},
+    {"setItem", NULL},
+    {NULL, NULL}
+};
+
+library_t chest::methods = {"!!MULTITYPE", chest_reg, nullptr, nullptr};
+std::vector<std::string> chest::types = {"inventory", "chest", "minecraft:chest"};

--- a/src/peripheral/chest.cpp
+++ b/src/peripheral/chest.cpp
@@ -2,7 +2,7 @@
  * peripheral/chest.cpp
  * CraftOS-PC 2
  * 
- * This file defines the methods for the chests peripheral.
+ * This file defines the methods for the chest peripheral.
  * 
  * This code is licensed under the MIT License.
  * Copyright (c) 2019-2022 JackMacWindows.
@@ -85,4 +85,4 @@ static luaL_Reg chest_reg[] = {
 };
 
 library_t chest::methods = {"!!MULTITYPE", chest_reg, nullptr, nullptr};
-std::vector<std::string> chest::types = {"inventory", "chest", "minecraft:chest"};
+std::vector<std::string> chest::types = {"minecraft:chest", "inventory", "chest"};

--- a/src/peripheral/chest.hpp
+++ b/src/peripheral/chest.hpp
@@ -1,0 +1,42 @@
+/*
+ * peripheral/chest.hpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the class for the chest peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows. 
+ */
+
+#ifndef PERIPHERAL_CHEST_HPP
+#define PERIPHERAL_CHEST_HPP
+#include "../util.hpp"
+#include <generic_peripheral/inventory.hpp>
+
+class chest: public inventory {
+    struct slot {
+        std::string name;
+        uint8_t count = 0;
+    };
+    bool isDouble = false;
+    slot items[54];
+    int setItem(lua_State *L);
+protected:
+    int size() override;
+    void getItemDetail(lua_State *L, int slot) override;
+    int addItems(lua_State *L, int slot, int count) override;
+    int removeItems(int slot, int count) override;
+public:
+    static library_t methods;
+    static std::vector<std::string> types;
+    static peripheral * init(lua_State *L, const char * side) {return new chest(L, side);}
+    static void deinit(peripheral * p) {delete (chest*)p;}
+    destructor getDestructor() const override {return deinit;}
+    library_t getMethods() const override {return methods;}
+    std::vector<std::string> getTypes() const override {return types;}
+    chest(lua_State *L, const char * side);
+    ~chest();
+    int call(lua_State *L, const char * method) override;
+};
+
+#endif

--- a/src/peripheral/energy.cpp
+++ b/src/peripheral/energy.cpp
@@ -1,0 +1,56 @@
+/*
+ * peripheral/energy.cpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the methods for the energy peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows.
+ */
+
+#include "energy.hpp"
+
+int energy::getEnergy() {
+    return currentEnergy;
+}
+
+int energy::getEnergyCapacity() {
+    return maxEnergy;
+}
+
+int energy::setEnergy(lua_State *L) {
+    currentEnergy = min(max((int)luaL_checkinteger(L, 1), 0), maxEnergy);
+    return 0;
+}
+
+energy::energy(lua_State *L, const char * side) {
+    maxEnergy = luaL_optinteger(L, 3, maxEnergy);
+    if (lua_istable(L, 4)) {
+        lua_pushinteger(L, 1);
+        lua_gettable(L, 4);
+        for (int i = 2; lua_isstring(L, -1); i++) {
+            types.push_back(tostring(L, -1));
+            lua_pop(L, 1);
+            lua_pushinteger(L, i);
+            lua_gettable(L, 4);
+        }
+        lua_pop(L, 1);
+    } else if (!lua_isnoneornil(L, 4)) luaL_checktype(L, 4, LUA_TTABLE);
+}
+
+energy::~energy() {}
+
+int energy::call(lua_State *L, const char * method) {
+    const std::string m(method);
+    if (m == "setEnergy") return setEnergy(L);
+    else return energy_storage::call(L, method);
+}
+
+static luaL_Reg energy_reg[] = {
+    {"getEnergy", NULL},
+    {"getEnergyCapacity", NULL},
+    {"setEnergy", NULL},
+    {NULL, NULL}
+};
+
+library_t energy::methods = {"!!MULTITYPE", energy_reg, nullptr, nullptr};

--- a/src/peripheral/energy.hpp
+++ b/src/peripheral/energy.hpp
@@ -1,0 +1,36 @@
+/*
+ * peripheral/energy.hpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the class for the energy peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows. 
+ */
+
+#ifndef PERIPHERAL_ENERGY_HPP
+#define PERIPHERAL_ENERGY_HPP
+#include "../util.hpp"
+#include <generic_peripheral/energy_storage.hpp>
+
+class energy: public energy_storage {
+    int currentEnergy = 0;
+    int maxEnergy = 1'000'000'000;
+    std::vector<std::string> types = {"energy", "energy_storage"};
+    int setEnergy(lua_State *L);
+protected:
+    int getEnergy() override;
+    int getEnergyCapacity() override;
+public:
+    static library_t methods;
+    static peripheral * init(lua_State *L, const char * side) {return new energy(L, side);}
+    static void deinit(peripheral * p) {delete (energy*)p;}
+    destructor getDestructor() const override {return deinit;}
+    library_t getMethods() const override {return methods;}
+    std::vector<std::string> getTypes() const override {return types;}
+    energy(lua_State *L, const char * side);
+    ~energy();
+    int call(lua_State *L, const char * method) override;
+};
+
+#endif

--- a/src/peripheral/tank.cpp
+++ b/src/peripheral/tank.cpp
@@ -1,0 +1,157 @@
+/*
+ * peripheral/tank.cpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the methods for the tank peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows.
+ */
+
+#include "tank.hpp"
+
+int tank::tanks(lua_State *L) {
+    lua_createtable(L, tankCount, 0);
+    for (int i = 0; i < tankCount; i++) {
+        lua_newtable(L);
+        int j = 1;
+        for (const auto& fluid : fluids[i]) {
+            lua_createtable(L, 0, 2);
+            lua_pushlstring(L, fluid.first.c_str(), fluid.first.size());
+            lua_setfield(L, -2, "name");
+            lua_pushinteger(L, fluid.second);
+            lua_setfield(L, -2, "amount");
+            lua_rawseti(L, -2, j++);
+        }
+        lua_rawseti(L, -2, i+1);
+    }
+    return 1;
+}
+
+int tank::addFluid(const std::string& name, int amount) {
+    // First try to add all the fluid in a contiguous amount if possible,
+    // and if not then add it split across the tanks.
+    std::vector<int> freeSpace(tankCount, tankCapacity);
+    for (int i = 0; i < tankCount; i++) {
+        for (const auto& fluid : fluids[i]) freeSpace[i] -= fluid.second;
+        if (freeSpace[i] >= amount) {
+            for (auto& fluid : fluids[i]) {
+                if (fluid.first == name) {
+                    fluid.second += amount;
+                    return amount;
+                }
+            }
+            fluids[i][name] = amount;
+            return amount;
+        }
+    }
+    const int total = amount;
+    for (int i = 0; i < tankCount && amount > 0; i++) {
+        if (freeSpace[i] == 0) continue;
+        int d = min(amount, freeSpace[i]);
+        for (auto& fluid : fluids[i]) {
+            if (fluid.first == name) {
+                fluid.second += d;
+                amount -= d;
+                d = 0;
+                break;
+            }
+        }
+        if (d) {
+            fluids[i][name] = d;
+            amount -= d;
+        }
+    }
+    return total - amount;
+}
+
+std::list<std::pair<std::string, int>> tank::removeFluid(const std::string& name, int amount) {
+    std::list<std::pair<std::string, int>> retval;
+    if (name == "") {
+        for (int i = 0; i < tankCount && amount > 0; i++) {
+            for (auto it = fluids[i].begin(); amount > 0 && it != fluids[i].end(); it = fluids[i].begin()) {
+                if (amount >= it->second) {
+                    retval.push_back(*it);
+                    amount -= it->second;
+                    fluids[i].erase(it);
+                } else {
+                    retval.push_back(std::make_pair(it->first, amount));
+                    it->second -= amount;
+                    amount = 0;
+                    break;
+                }
+            }
+        }
+    } else {
+        for (int i = 0; i < tankCount && amount > 0; i++) {
+            for (auto& fluid : fluids[i]) {
+                if (fluid.first == name) {
+                    if (amount >= fluid.second) {
+                        retval.push_back(fluid);
+                        amount -= fluid.second;
+                        fluids[i].erase(fluid.first);
+                    } else {
+                        retval.push_back(std::make_pair(fluid.first, amount));
+                        fluid.second -= amount;
+                        amount = 0;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    return retval;
+}
+
+tank::tank(lua_State *L, const char * side) {
+    tankCount = luaL_optinteger(L, 3, tankCount);
+    tankCapacity = luaL_optinteger(L, 4, tankCapacity);
+    fluids.resize(tankCount);
+    if (lua_istable(L, 5)) {
+        lua_pushinteger(L, 1);
+        lua_gettable(L, 5);
+        for (int i = 2; lua_isstring(L, -1); i++) {
+            types.push_back(tostring(L, -1));
+            lua_pop(L, 1);
+            lua_pushinteger(L, i);
+            lua_gettable(L, 5);
+        }
+        lua_pop(L, 1);
+    } else if (!lua_isnoneornil(L, 5)) luaL_checktype(L, 5, LUA_TTABLE);
+}
+
+tank::~tank() {}
+
+int tank::call(lua_State *L, const char * method) {
+    std::string m(method);
+    if (m == "addFluid") {
+        lua_pushinteger(L, addFluid(checkstring(L, 1), luaL_checkinteger(L, 2)));
+        return 1;
+    } else if (m == "removeFluid") {
+        size_t sz = 0;
+        const char * s = luaL_optlstring(L, 1, "", &sz);
+        auto retval = removeFluid(std::string(s, sz), luaL_optinteger(L, 2, INT_MAX));
+        lua_newtable(L);
+        int j = 1;
+        for (const std::pair<std::string, int>& fluid : retval) {
+            lua_createtable(L, 0, 2);
+            lua_pushlstring(L, fluid.first.c_str(), fluid.first.size());
+            lua_setfield(L, -2, "name");
+            lua_pushinteger(L, fluid.second);
+            lua_setfield(L, -2, "amount");
+            lua_rawseti(L, -2, j++);
+        }
+        return 1;
+    } else return fluid_storage::call(L, method);
+}
+
+static luaL_Reg tank_reg[] = {
+    {"tanks", NULL},
+    {"pushFluid", NULL},
+    {"pullFluid", NULL},
+    {"addFluid", NULL},
+    {"removeFluid", NULL},
+    {NULL, NULL}
+};
+
+library_t tank::methods = {"!!MULTITYPE", tank_reg, nullptr, nullptr};

--- a/src/peripheral/tank.hpp
+++ b/src/peripheral/tank.hpp
@@ -1,0 +1,37 @@
+/*
+ * peripheral/tank.hpp
+ * CraftOS-PC 2
+ * 
+ * This file defines the class for the tank peripheral.
+ * 
+ * This code is licensed under the MIT License.
+ * Copyright (c) 2019-2022 JackMacWindows. 
+ */
+
+#ifndef PERIPHERAL_TANK_HPP
+#define PERIPHERAL_TANK_HPP
+#include "../util.hpp"
+#include <generic_peripheral/fluid_storage.hpp>
+
+class tank: public fluid_storage {
+    int tankCount = 1;
+    int tankCapacity = 256;
+    std::vector<std::unordered_map<std::string, int>> fluids;
+    std::vector<std::string> types = {"tank", "fluid_storage"};
+protected:
+    int tanks(lua_State *L) override;
+    int addFluid(const std::string& fluid, int amount) override;
+    std::list<std::pair<std::string, int>> removeFluid(const std::string& fluid, int amount) override;
+public:
+    static library_t methods;
+    static peripheral * init(lua_State *L, const char * side) {return new tank(L, side);}
+    static void deinit(peripheral * p) {delete (tank*)p;}
+    destructor getDestructor() const override {return deinit;}
+    library_t getMethods() const override {return methods;}
+    std::vector<std::string> getTypes() const override {return types;}
+    tank(lua_State *L, const char * side);
+    ~tank();
+    int call(lua_State *L, const char * method) override;
+};
+
+#endif


### PR DESCRIPTION
This PR adds some default generic peripheral types: `minecraft:chest` (aliased as `chest`), `tank`, and `energy`. The latter two can be constructed with an optional list of types to allow code that look for specific types of `fluid_storage`/`energy_storage` peripherals to use these peripherals, as well as custom capacities. All peripherals implement extra functions to set the contents.

Closes: #260