### PR TITLE
Only run CI when `src/` changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    paths:
+      - "src"
+      - ".github/workflows"
+  pull_request:
+    paths:
+      - "src"
+      - ".github/workflows"
 
 jobs:
 


### PR DESCRIPTION
This PR changes your build/test GitHub Action to be more efficient by only executing if the code changed.

This helps you save CI minutes when devs or contributors make a documentation change.