### PR TITLE
Add clarification for CraftOS-PC portable builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visit the website at https://www.craftos-pc.cc/ for more information, including 
   * Arch Linux with AUR helper
   * iOS 11.0+
   * Android 7.0+
-* Administrator privileges
+* Administrator privileges (when using the installer)
 * 20-50 MB free space
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Visit the website at https://www.craftos-pc.cc/ for more information, including 
   * Arch Linux with AUR helper
   * iOS 11.0+
   * Android 7.0+
-* Administrator privileges (when using the installer)
 * 20-50 MB free space
 
 ## Installing


### PR DESCRIPTION
I added a note, the portable builds dont require administrator privileges. It might deter users that want to use this on a school laptop when they read that.