### PR TITLE
Adding term.forceUpdate() function.

### DIFF
--- a/api/Terminal.hpp
+++ b/api/Terminal.hpp
@@ -152,6 +152,7 @@ public:
 
     // The following fields are available in API version 10.1 and later.
     bool frozen = false; // Whether the terminal should stop rendering
+    bool forcedUpdate = false; // Ignores `frozen` to render the terminal once 
 
     // The following fields are available in API version 10.2 and later.
     std::list<uint8_t> mouseButtonOrder; // An ordered list of mouse buttons that have been pressed

--- a/src/apis/http.cpp
+++ b/src/apis/http.cpp
@@ -1364,7 +1364,9 @@ static int websocket_server_listen(lua_State *L) {
  */
 static int websocket_server_close(lua_State *L) {
     lastCFunction = __func__;
+    Computer * comp = get_comp(L);
     websocket_server::Factory * f = *(websocket_server::Factory**)lua_touserdata(L, lua_upvalueindex(1));
+    comp->openWebsocketServers.erase(f->srv->port());
     if (f == NULL) return 0;
     f->srv->stop();
     delete f->srv;
@@ -1374,7 +1376,9 @@ static int websocket_server_close(lua_State *L) {
 
 static int websocket_server_free(lua_State *L) {
     lastCFunction = __func__;
+    Computer * comp = get_comp(L);
     websocket_server::Factory * f = *(websocket_server::Factory**)lua_touserdata(L, 1);
+    comp->openWebsocketServers.erase(f->srv->port());
     if (f == NULL) return 0;
     f->srv->stop();
     delete f->srv;

--- a/src/apis/term.cpp
+++ b/src/apis/term.cpp
@@ -649,6 +649,15 @@ static int term_getFrozen(lua_State *L) {
     return 1;
 }
 
+static int term_forceUpdate(lua_State *L) {
+    lastCFunction = __func__;
+    Terminal * term = get_comp(L)->term;
+    if (term == NULL) return 0;
+    std::lock_guard<std::mutex> lock(term->locked);
+    term->forcedUpdate = true;
+    return 0;
+}
+
 /* export */ int term_benchmark(lua_State *L) {
     lastCFunction = __func__;
     if (get_comp(L)->term == NULL) return 0;
@@ -695,6 +704,7 @@ static luaL_Reg term_reg[] = {
     {"relativeMouse", term_relativeMouse},
     {"setFrozen", term_setFrozen},
     {"getFrozen", term_getFrozen},
+    {"forceUpdate", term_forceUpdate},
     {NULL, NULL}
 };
 

--- a/src/peripheral/monitor.cpp
+++ b/src/peripheral/monitor.cpp
@@ -569,6 +569,14 @@ int monitor::setBlockSize(lua_State *L) {
     return 0;
 }
 
+int monitor::forceUpdate(lua_State *L) {
+    lastCFunction = __func__;
+    if (term == NULL) return 0;
+    std::lock_guard<std::mutex> lock(term->locked);
+    term->forcedUpdate = true;
+    return 0;
+}
+
 int monitor::call(lua_State *L, const char * method) {
     std::string m(method);
     if (m == "write") return write(L);

--- a/src/peripheral/monitor.hpp
+++ b/src/peripheral/monitor.hpp
@@ -51,6 +51,7 @@ private:
     int getFrozen(lua_State *L);
     int setSize(lua_State *L);
     int setBlockSize(lua_State *L);
+    int forceUpdate(lua_State *L);
 public:
     Terminal * term;
     static library_t methods;

--- a/src/termsupport.cpp
+++ b/src/termsupport.cpp
@@ -582,8 +582,9 @@ static bool renderTerminal(Terminal * term, bool& pushEvent) {
             term->last_blink = std::chrono::high_resolution_clock::now();
             term->changed = true;
         }
-        if (term->frozen) return false;
+        if (term->frozen && !term->forcedUpdate) return false;
         changed = term->changed;
+        term->forcedUpdate = false;
     }
     try {
         term->render();


### PR DESCRIPTION
There is currently no way to syncronise when to freeze and unfreeze the terminal/monitor once a Lua program is finished drawing, so I've made this function to force it (just ignore that it's frozen) to render the contents of the terminal once. (A better name can be chosen if needed.)

The ROM should also now expect this function or else it will give an error "Redirect object is missing method forceUpdate."