### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
         $code = Get-Content .\retval.txt
         if ( $code -ne 0 ) { exit $code }
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: CraftOS-PC-Artifact
         path: |
@@ -213,7 +213,7 @@ jobs:
           CraftOS-PC_console.exe
           lua52.dll
     - name: Upload artifact symbols
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: CraftOS-PC-Artifact-Symbols
         path: |


### PR DESCRIPTION
CI runs have started failing due to this:
https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/