### PR TITLE
platform: alias strcasecmp to _stricmp on Windows

### DIFF
--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -43,3 +43,7 @@ extern void addSystemCertificates(Poco::Net::Context::Ptr context);
 extern void unblockInput();
 extern bool winFolderIsReadOnly(path_t path);
 #endif
+
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#endif


### PR DESCRIPTION
This fixes the build on Windows!

(At least, I think... I used GitHub Actions as my testing platform, and it fails on my fork with only an API key-related error, so I'm pretty confident that this change fixes the build.)